### PR TITLE
Write down how TODO.md records a finished item

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,13 @@
 # TODO
 This document is the canonical source that aggregates incomplete tasks managed across the whole repository.
 
+**How a finished item is recorded.** Do not delete a completed item. Keep it in place and append a
+`- **DONE (<what closed it>, <date>).**` sub-bullet stating the evidence, so that the reasoning which
+closed it stays readable next to the problem it closed. A top-level item is removed only when it turns
+out never to have been a task (withdrawn or duplicated), not when it is finished. Measured over the
+file's history on 2026-08-13: of the 71 commits that touch it, 42 add a `**DONE` line and 6 remove a
+top-level item.
+
 ## TODO list
 
 - Once the Claude backend can obtain `session_id` or `agent_session_id` from the hook payload, abolish the `agent_run_id` resolution that depends on `active_child_agent_run_id.txt`, and unify it to the same session-identifier-based resolution as the Codex backend.


### PR DESCRIPTION
One-line-of-substance doc change, split out of PR #55 rather than smuggled into it.

In #55 I deleted a completed TODO item instead of annotating it `**DONE`, and only learned the convention when a reviewer pushed back. The convention was real but **unwritten** — it existed only in the file's history, so the next person (or agent) hits the same wall.

Measured rather than asserted: of the **71** commits that touch `TODO.md`, **42** add a `**DONE` line and **6** remove a top-level item — and those 6 are withdrawals/duplicates, not completions. (In #55 I first repeated a reviewer's figures, 30/26, as my own measurement; these are mine.)

Verification: `test_orchestration_runtime.py` + `test_validate_pipeline_semantics.py` (the two suites that read `TODO.md`) — 1854 passed, 1 skipped. `TODO.md` is not in the child-context doc-size ceiling table, so no budget impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)