### PR TITLE
Record three review-loop lessons PR #81 paid for

### DIFF
--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -330,7 +330,8 @@ correctness+regression+doc-truth).
   one implemented member" **refused the docs' three-step "Adding an axis" outright** (a new axis
   has neither an implementation nor a declarable capability) → ③ extending the duplicate-definition
   guard to dict values flagged a legitimate mapping. **Miss-direction bugs come one per round;
-  over-refusal comes in a new shape with every rewrite.** Four countermeasures: (a) for each check
+  over-refusal comes in a new shape with every rewrite.** Four countermeasures that DETECT it —
+  a fifth that prevents it is the next bullet: (a) for each check
   you write, construct one piece of correct work that violates it, (b) **keep the over-refusal probe
   in the reviewer instructions through the final round** (not once), (c) if over-refusals persist
   after two rewrites, conclude **the rule is not an invariant** and change its shape, (d) **build
@@ -340,6 +341,21 @@ correctness+regression+doc-truth).
   and a reviewer produced it just by reading the ledger. Implementing the next TODO / plan item is
   the cheapest over-refusal probe there is (PR #67 landed on "a census that constrains nobody's
   registration" = moving the target from a rule to **checking the declaration**)
+- **A fifth countermeasure, and the one that actually worked: when you add a FLOOR, default to
+  FILL rather than REFUSE.** The others detect over-refusal after you write it; this one stops you
+  writing it. Ask what the missing thing IS. An input that omits a value has said nothing that
+  contradicts you — and if the value is something the layer already knows (its own arguments, a
+  field the record carries), supply it. Refuse only a DISAGREEMENT, where two sources make
+  incompatible claims and you cannot tell which is wrong. PR #81 got this backwards first: told
+  that a fallback path skipped an id check, I made it refuse, and one exported variable took the
+  suite from 4971 passed to 152 failed while production turned the same `ValueError` into
+  `fail_closed` — an unreachable stale record traded for a reachable killed run. Rewritten as
+  "overwrite the stale value, refuse only a disagreement" it fixed the finding and broke nothing.
+  The two later floors on that PR were written FILL-first for this reason, and the second is the
+  clearest case: refusing a profile that lacked the ids would have rejected every profile
+  persisted before the branch, i.e. broken `--resume` of an older run, while filling them from the
+  record's own fields cost one line. **Before writing a refusal into a floor, name the legitimate
+  input it rejects.** If you cannot, you have not looked; if you can, that input is the test.
 
 **Reproduce a finding yourself before classifying it.** Real / false positive / residual /
 **real but out of scope** (below) are decided only with a record of a reproduction you ran. Treat

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -200,6 +200,16 @@ Test-file hunks are excluded by default (`--include-tests`
     the docstring claims to drive
   - **kill enumerations one element at a time** (regex alternatives, keyword tables); checked
     together, a missing element goes unnoticed
+  - **when a comment JUSTIFIES a rule, mutate the property the justification names.** The rule
+    usually has a witness and the property holding it up usually does not. On PR #81 the
+    surviving justification for passing `METDSL_*` by prefix was "the names that redirect a leaf
+    are outside the prefix BY CONSTRUCTION" — true only because the match is anchored, and
+    `startswith` -> `in` kept all 4972 tests green, admitting `MY_METDSL_API_KEY`. The neighbouring
+    spelling too: the prefix STRING was separately unpinned, and shortening `"METDSL_"` to
+    `"METDS"` stayed green while widening the namespace to one the repo does not own. Read your own
+    justification as a list of claims and write one mutant per claim — and note this is the sign's
+    other half: rewriting a justification three times (below) is when its supporting property is
+    newest and least witnessed
   - **one test per occurrence of a rule, not per rule** (PR #53: the same line in three gates, two
     of them surviving as reachable fail-opens)
   - **for stateful code, match the fixture to the lifetime of the state**, and always include a
@@ -278,6 +288,21 @@ correctness+regression+doc-truth).
     (a) for work the harness tracks, **do not poll — the completion notification arrives**, (b)
     **wait on the PID** (`while kill -0 <pid> 2>/dev/null; do sleep N; done`), (c) split the
     matching string. **The end-of-round check is `ListAgents` and `ps`, both**
+  - **Evaluate the exit condition ONCE, by hand, before you leave a wait running.** "Can be
+    satisfied" is not a property you can see by reading — twice on PR #81 I wrote a
+    condition that was false for every possible input, the second being
+    `until grep -qE "…" a.txt b.txt | grep -c . | grep -q 2`: `-q` prints nothing, so the count is
+    always `0` and no suite result could ever end it. It also survives the thing it waits for:
+    the other one watched an output file whose producer I had killed, so it polled a
+    permanently empty file. Run the condition once and look at the exit status; if it is already the
+    value that ends the loop, the loop is pointless, and if it cannot reach that value it is an
+    orphan you have not noticed yet
+  - **Two things make the end-of-round `ps` check actually fire.** (i) it is a reconciliation, not
+    a memory: keep the PID of every wait you start and match the list, because "did I leave one
+    running" is exactly the question a tired reviewer answers wrong; (ii) **a backgrounded wait
+    returns immediately** — you get a task id, not a pause — so a turn that launches one and then
+    keeps working has NOT waited, and the loop is still out there. On PR #81 I noticed
+    that mid-session, said so, and still left two behind for the user to find
 - **Include "build your own mutants that delete one mechanism at a time, run them, and report
   survivors".** Do not hand over your mutation list — independence is the point (see L174 above)
 - **If the reported HEAD is a hash you do not recognize, find out what commit it is first.** Even


### PR DESCRIPTION
Three additions to `.claude/skills/metdsl-review-loop/SKILL.md`, all from the 4-round
review of #81. **None of them is a rule the skill was missing** — in every case the
governing rule was already there and its trigger point was somewhere else, so it did not
fire. That is what the additions record.

## 1. Mutate the property a justification NAMES, not just the rule

#81 rewrote one comment's justification three times; reviewers falsified the first two.
The third — *"the names that redirect a leaf are outside the prefix BY CONSTRUCTION"* — is
true only because the prefix match is anchored, and `startswith` → `in` kept **all 4972
tests green** while admitting `MY_METDSL_API_KEY`. The prefix STRING was separately
unpinned: shortening `"METDSL_"` to `"METDS"` also stayed green, widening the namespace to
one this repository does not own.

The rule had witnesses. The two properties holding its *justification* up had none. Filed
beside "kill enumerations one element at a time" because it is the same move one level up,
and cross-referenced to the existing "rewritten the same string three times" sign — that
sign is exactly the moment a supporting property is newest and least witnessed.

## 2. Evaluate a wait's exit condition once, and reconcile waits by PID

The skill already says to create only waits that can be satisfied, and that the
end-of-round check is `ListAgents` **and** `ps`. Twice on #81 I wrote a condition that was
false for every possible input — `until grep -qE "…" a.txt b.txt | grep -c . | grep -q 2`,
where `-q` prints nothing so the count is always `0` — and left two loops spinning for the
user to find.

The missing halves: "can be satisfied" is not visible by reading, so run the condition once
and look at the exit status; and a **backgrounded wait returns immediately**, so a turn that
launches one and keeps working has not waited. I noticed that mid-session, said so out loud,
and still left two behind — which is why the end-of-round check has to be a reconciliation
against PIDs kept at launch rather than an act of memory.

## 3. When you add a FLOOR, default to FILL rather than REFUSE

The four countermeasures already listed all catch over-refusal *after* it is written. This
one acts earlier, and it is the one that actually worked on #81.

Ask what the missing thing IS. An input that omits a value has said nothing that
contradicts you; if the value is something the layer already knows — its own arguments, a
field the record carries — supply it. Refuse only a DISAGREEMENT, where two sources make
incompatible claims and there is no way to tell which is wrong.

#81 got this backwards first. Told that a fallback path skipped an id check, I made it
refuse; one exported variable then took the suite **from 4971 passed to 152 failed**, and in
production the same `ValueError` became `fail_closed` — an unreachable stale record traded
for a reachable killed run. Rewritten as "overwrite the stale value, refuse only a
disagreement" it closed the finding and broke nothing. The two floors added later were
written FILL-first for this reason, and the second shows the cost most clearly: refusing a
profile that lacked the ids would have rejected every profile persisted before the branch —
breaking `--resume` of an older run — while filling them from the record's own fields cost
one line.

Operative test: **before writing a refusal into a floor, name the legitimate input it
rejects.** If you cannot, you have not looked; if you can, that input is the test.

## Verification, and its limits

Every number and code claim re-checked against merged `main` and the commit that measured
it: `4971 → 152` is recorded in `640fd47`'s message; both later floors really are fills
(`body.setdefault(name, expected)`, and the deliverer filling from the profile's own
recorded ids). The parent bullet is renumbered, since it said "Four countermeasures" while
the new one calls itself the fifth — the prose/count drift this file elsewhere tells you to
turn into a check.

**No test reads this file.** `.claude/skills/**` is outside the child-context doc size
ceilings, which cover only the five leaf-facing `skills/workflow-*` docs, so this is prose
review only and carries no mechanical guarantee. `test_mutation_check.py` still passes
49/49 because the script is untouched.

Also fixes a stray non-ASCII word I typed into this English file while drafting, and
replaces an ambiguous "the leaf-env PR" with the PR number, matching the file's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESyPQM7uvkZmvMQoA5FyXc