### PR TITLE
Record three review-loop traps PR #86 paid for

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/SKILL.md
+++ b/.claude/skills/metdsl-enforcement-change/SKILL.md
@@ -339,6 +339,36 @@ close a path opened a new one**.
   sharing, write into the design the sentence that **a write to the shared object is an input to
   the other leaves**
 
+**Surface 9: "it moved under something the other side already covers" is a claim about a
+CONFIGURATION, and it holds only for the configurations you enumerated.** Surfaces 7 and 8 are
+about what a flag leaves open and what an isolation dir lets in. This one is the reassuring
+version of the same mistake: you move a protected thing so that an EXISTING rule covers it, and
+write that the closure came for free.
+
+Hit on PR #86. The isolated backend homes moved under `operator_secret_root()`, which the Bash
+read guard refuses unconditionally, so enforcement did appear to come for free and only the
+attribution looked resolver-dependent. But the location is relocatable by an environment
+variable, and with it pointed outside that root a leaf could read a SIBLING orchestration's
+transcript — measured — while three documents asserted the closure with no mention of the
+condition. Worse, one of those documents was a docstring I had written "MEASURED, both
+directions" next to, having measured only the default. Codex found it; four subagent rounds had
+not.
+
+- **Enumerate what can MOVE the thing before writing that it is covered**: an environment
+  override, a config key, a CLI flag, a symlink, a different `$HOME`. Each is a configuration in
+  which the claim must be re-checked, and the check is one execution each
+- **The fix that survives is one resolver, not one sentence.** Documenting the condition leaves
+  the reader to remember it. Moving the resolution into the module that owns the protected-root
+  list, and having the writer import it, makes the tree that gets created the tree that gets
+  guarded by construction. That is the same arrangement the repo already uses for
+  `backend_credential_home_paths` — when a rule keeps needing a caveat, look for a
+  neighbouring pair that already solved it
+- **Attribution is not enforcement, and adding a longer protected root changes it silently.**
+  Roots are sorted longest-path-first, so a new entry beneath an existing one takes over the
+  block message for everything under it. The read stays refused; the id in the message changes,
+  and any test or document that named the old id becomes false. Check both, and keep a control
+  read that must still be attributed to the root above
+
 ### 2. Confirm the path production actually takes
 
 **Production does not necessarily pass the argument you wrote the rule on.** In PR #51 the rule

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -169,7 +169,11 @@ Test-file hunks are excluded by default (`--include-tests`
   `str.replace` rewriting all occurrences at once so per-site mutation showed 2 of the 3
   surviving, both of them reachable fail-opens. If you must, **count the occurrences and hit them
   one at a time**, and **assert the
-  patch applied** — a mutation that did not apply is indistinguishable from green (PR #76). The
+  patch applied** — a mutation that did not apply is indistinguishable from green (PR #76).
+  **A mutant list REUSED across rounds goes stale as the source moves**, and then reports as a
+  survivor: on PR #86 three "survivors" in one sweep were stale target strings, visible only
+  because the harness printed `PATCH DID NOT APPLY` instead of counting them green. Re-point them
+  before reading the result, and treat a not-applied patch as a failed run rather than a finding. The
   script is not universal either: one hunk can bundle a pinned and an unpinned change, so **follow
   up at line granularity when one rule lives in N places**
 - **Never revert a mutation with `git checkout -- <file>`; it deletes uncommitted work too** (done
@@ -200,6 +204,25 @@ Test-file hunks are excluded by default (`--include-tests`
     the docstring claims to drive
   - **kill enumerations one element at a time** (regex alternatives, keyword tables); checked
     together, a missing element goes unnoticed
+  - **a test can pass because of the SUITE'S OWN ENVIRONMENT.** Distinct from "two paths to the
+    outcome": here the fixture is fine and `conftest.py` is what decides the verdict. On PR #86 a
+    session fixture redirected `METDSL_WORKFLOW_HOMES_ROOT` for every test, so a test asserting
+    which protected root a path falls under was reasoning about a nesting that did not exist while
+    it ran — green under pytest, **failing under `env -u <VAR> python3 -m unittest <dotted.path>`**,
+    which is the production resolution. Two tests on that branch had it.
+    - **The tell**: the test reasons about a RELATIONSHIP (this path is under that root, this id
+      matches that record) whose two halves are not both built by the fixture
+    - **The check is one command.** Run the branch's new test classes both ways and diff the
+      verdicts. Cheap enough to be routine when conftest touches the environment at all
+    - **The fix is not to unset the variable — it is to build the relationship in the fixture**, so
+      the test asserts the workflow's answer instead of the harness's
+  - **a mechanism that guards the HARNESS cannot be witnessed from inside the suite.** If the same
+    protection also comes from `conftest.py`, every mutant of it is green there, and the thing it
+    prevents happens only where conftest is not loaded. PR #86's module-level redirect — added
+    after two reviewers wrote real directories into the operator's home — survived every mutation
+    until the witness left the process: **a subprocess running a dependent class under plain
+    `unittest` with a fake `$HOME`, asserting the directory never appears.** Reach for this
+    whenever the mechanism's whole purpose is what happens outside the runner you are testing under
   - **when a comment JUSTIFIES a rule, mutate the property the justification names.** The rule
     usually has a witness and the property holding it up usually does not. On PR #81 the
     surviving justification for passing `METDSL_*` by prefix was "the names that redirect a leaf


### PR DESCRIPTION
Three traps from PR #86's review loop (six subagent rounds plus a Codex pass on issue #64). Two are about tests that were green for reasons unrelated to the code; the third is about a closure claim that held only in the configuration I happened to measure.

- **`metdsl-review-loop`** — a test can pass because of the suite's own environment (`conftest.py` deciding the verdict, not the fixture); and a mechanism that guards the harness cannot be witnessed from inside the suite, so its witness has to leave the process.
- **`metdsl-enforcement-change`** — new **Surface 9**: "it moved under something the other side already covers" is a claim about a CONFIGURATION, and holds only for the configurations you enumerated. Includes the note that a new longer protected root silently takes over the block MESSAGE beneath it, so attribution and enforcement must be checked separately.
- One clause on reused mutant lists going stale and reporting as survivors.

Each entry carries the episode that produced it, per this repository's convention for these files. Deliberately excluded: the domain facts the same branch measured (`os.mkdir`'s mode is masked by the umask, `os.chmod` follows symlinks) — those live in the code that depends on them.

Depends on nothing in #86 and touches no file that PR touches; the `references/dual-read-pairs.md` row about the same move stays on #86, where the change it describes lives.

Measured: `python3 -m pytest tools/tests -q` = 5048 passed, unchanged — nothing under `.claude/skills/` is read by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESyPQM7uvkZmvMQoA5FyXc