### PR TITLE
Record what TODO:269's review loop taught the two review skills

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/references/verification.md
+++ b/.claude/skills/metdsl-enforcement-change/references/verification.md
@@ -114,6 +114,14 @@ done
 available (1 hidden fix can be enabled with the --unsafe-fixes option).` — in both cases the count
 is on the line above. Read the full output whenever the last lines differ.
 
+**If you want a NUMBER, ask ruff for it: `ruff check --statistics <f>`.** Do not write a counter
+for the occasion. On TODO:269 the count went into the ledger from `ruff check <f> | grep -c
+"^[A-Z][0-9]*"`, where `[0-9]*` matches zero digits, so `No fixes available` and its neighbours
+were counted as findings — four numbers wrong in one sentence, all four reproduced by a reviewer
+in minutes. The comparison itself survived (the same wrong counter ran on both sides), which is
+the shape that makes this kind of bug last: **the claim that matters can be true while every
+number in it is false.**
+
 Same reason as above, and one of this loop's own rules besides: the earlier form used `git stash`
 plus `git checkout -- .`, and `metdsl-review-loop` forbids `git checkout -- <path>` by name for
 discarding uncommitted work along with whatever it was meant to revert.
@@ -218,6 +226,71 @@ rg -n "violations.append|raise (ValueError|RuntimeError)" <touched file>
 
 **If you wrote a measured value as grounds, re-measure it after the change.** In PR #51 the same
 string was rewritten four times.
+
+**One match expression is not a census, and calling it one is a false claim about coverage.** On
+TODO:269 the post_judge disposition rule was stated in six documents. Reading and grepping found
+2; enumerating every `.md` with `os.walk` and matching lines carrying both `disposition` and
+`recoverable` found 5, and that was written up as "the record of how many sites there are"; a
+reviewer matching `post_judge` + `fail_closed` found the 6th, which states the same rule using the
+word **severity**. The remedy is cheap — **run two or three expressions built from DIFFERENT words
+in the rule, and stop only when they agree**:
+
+```bash
+# enumerate files yourself: `grep` is shadowed in an agent session and respects .gitignore
+python3 - <<'PY'
+import os, re
+PATS = [("disposition", "recoverable"), ("post_judge", "fail_closed"), ("warm-resum", "judge")]
+for root, _, files in os.walk("."):
+    if "/.git" in root: continue
+    for f in files:
+        if not f.endswith((".md", ".py")): continue
+        p = os.path.join(root, f)
+        for i, line in enumerate(open(p, errors="ignore"), 1):
+            for a, b in PATS:
+                if a in line and b in line: print(f"{p}:{i}  [{a}+{b}]")
+PY
+```
+
+If the expressions disagree, the rule is stated in more than one vocabulary and the widest answer
+is the census. **Say which expressions you ran** — "I enumerated every `.md`" describes the file
+walk, not the matching, and the matching is where the miss was.
+
+## The backend-boundary token ratchet (run it on every commit that touches a scanned file)
+
+`tools/tests/test_backend_boundary.py::TokenRatchetTests` counts technology tokens per file and
+fails on growth. **It reads WHOLE FILES, so an ordinary comment trips it** — and a commit whose
+verification runs only the test file for the module it changed will not see that. On TODO:269 it
+tripped three times, all from prose, and one was caught two commits late for exactly that reason,
+after a commit message had already asserted "ratchet still green" without running it.
+
+```bash
+python3 -m pytest tools/tests/test_backend_boundary.py -q          # every commit touching tools/ or docs/
+python3 -m tools.tests.test_backend_boundary --write-baseline      # ONLY after the judgement below
+```
+
+**Three trips, three different right answers — the judgement is the whole content of this
+section:**
+
+- **A neutral-role citation → regenerate, and say so in the commit message.** Naming an existing
+  symbol the neutral core already exports (`FORTRAN_STRUCTURE_UNAVAILABLE_EXIT_CODE` at a new read
+  site) is not new technology knowledge. `AGENTS.md` permits naming an `axis` value as an opaque
+  token; the prohibition is on a file extension, keyword, grammar, compiler argument, lint rule
+  id, directive spelling, control-file syntax, naming convention or diagnostic format.
+- **A genuine addition → withdraw it, do not regenerate.** A RUNBOOK recovery entry spelled two
+  parser distribution names that `run_workflow.py`'s `REQUIRED_PYTHON_MODULES` already owns and
+  prints. Pointing at the refusal was both the neutral spelling and the better instruction — one
+  owner, no copy to go stale.
+- **Do NOT rename an identifier to get under the counter.** A reviewer will observe that some of
+  the growth was "avoidable by spelling" (a local alias bound once instead of a long name imported
+  twice). Reject that: it satisfies the instrument and not the rule, and it is the same habit
+  `docs/BACKEND_BOUNDARY.md` §Enforcement warns the ratchet itself can teach — regenerating
+  without reading the rule. Record the debt and the reasoning instead, so the operator can
+  overturn it.
+
+**A ratchet failure is also a false KILL in a mutation sweep.** Deleting an identifier to test
+something else moves the count, so the ratchet fails and the mutant reads as killed for a reason
+that has nothing to do with behaviour. On TODO:269 that hid an exit-code mapping with no
+behavioural witness at all. When a mutant dies, read WHICH row died.
 
 ## Mutation check
 

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -201,7 +201,16 @@ Test-file hunks are excluded by default (`--include-tests`
   - **a test that reproduces the wiring does not observe the wiring**: if it does not call the
     production entry point, it pins "the argument is forwarded", not "that value is chosen" (issue
     #63). **And that shape lies in its docstring easily** — grep the body for the function names
-    the docstring claims to drive
+    the docstring claims to drive. On TODO:269 a row named
+    `test_the_cli_answers_with_a_dedicated_exit_code`, whose comment said "this runs `main` in a
+    real interpreter", drove a gate helper and printed a module CONSTANT; `main` was never
+    entered, and the exit code it was named for had no witness at all
+  - **A CLASS docstring goes stale as rows are appended to the class, and nobody re-reads it.**
+    Distinct from the row above: the prose was TRUE when written and became false by addition. On
+    TODO:269 a class docstring said "these drive the REAL CLI in a REAL subprocess" when all its
+    rows did; two rows added later read module attributes, one of them calling `main` in-process
+    — **in a class I had created one round after renaming a sibling for exactly this**. When you
+    append a row to an existing class, re-read the class docstring as part of the append
   - **kill enumerations one element at a time** (regex alternatives, keyword tables); checked
     together, a missing element goes unnoticed
   - **a test can pass because of the SUITE'S OWN ENVIRONMENT.** Distinct from "two paths to the
@@ -235,6 +244,14 @@ Test-file hunks are excluded by default (`--include-tests`
     newest and least witnessed
   - **one test per occurrence of a rule, not per rule** (PR #53: the same line in three gates, two
     of them surviving as reachable fail-opens)
+  - **The sharpest trigger for that is a TWIN.** When a change touches one of a matched pair —
+    two exit codes, two markers, two gates, the two halves of a symmetry — **the witness you build
+    for one is the specification for the other, and building only one is the likeliest miss you
+    will make.** On TODO:269 I built a real-subprocess witness for exit code 4 and none for its
+    twin exit code 3, in the same commits, while adding three readers keyed on rc 3 plus a
+    `--help` line and a RUNBOOK entry: mutating rc 3's mapping to `return 1` left **1555 rows
+    green**, and three review rounds walked past it. The check is mechanical — **list the pair,
+    then list your witnesses, and compare the two lists** before handing over
   - **for stateful code, match the fixture to the lifetime of the state**, and always include a
     version with one level of syntactic nesting (PR #53: the round after the flat version was
     fixed, the nested version ate the fix)
@@ -245,6 +262,26 @@ Test-file hunks are excluded by default (`--include-tests`
    errors appeared on that one branch, the last of them in the PR body's disclosure section. What
    worked was **a script that substitutes the numbers in TODO / docs from the measurement
    artifacts**, run and diffed. Leave no path where a human transcribes.
+
+   **"Re-measure at the end" fails outright once a review loop starts, because the end keeps
+   moving.** On TODO:269 one paragraph rotted **three times, twice inside a commit whose stated
+   purpose was to restate it** — each restatement was correct when written and was falsified by
+   the next round's own fix commits, and reviewers reported the same two numbers in three
+   consecutive rounds. Note the shape: a fix commit adds a test or a hunk, so the very act of
+   answering a review finding invalidates the ledger that describes the branch.
+
+   - **The form is the bug, not the numbers. Write every measurement as a HISTORICAL RECORD that
+     names the commit it was taken at** ("at `7c6d187`: 17 hunks, 10 killed …"). A record cannot
+     go stale; a claim about the present can, and will, once per round. A reader who needs today's
+     figure runs the command.
+   - **State the PROPERTY the count stands for, next to the count** ("every behavioural hunk is
+     pinned"). That is the part the reader needs and the part that does not move — and it is what
+     survives when the number is obsolete anyway.
+   - **A count with no unit is not reproducible.** "14 hunks" was reported as 19 and as 16 by two
+     reviewers before anyone noticed the figure depends on the diff CONTEXT WIDTH (`-U0` / `-U3` /
+     `-U5` gave 21 / 17 / 15 on one range). Name the width, the command, and the exclusions.
+   - **Recording that a number "was right when written" does not stop the next rot** — that
+     sentence itself was written twice and rotted twice. Only changing the form stopped it.
 
 3. **Run the verification set** and record the measurements. The commands are in
    `.claude/skills/metdsl-enforcement-change/references/verification.md` (suite baseline, ruff
@@ -613,7 +650,8 @@ it** — do not add rounds waiting for it.
 relaunch a Codex you have no budget for**. Use Codex as one independent pass and finish once you
 have classified the result. Clean did come back once (PR #67), and **the same
 round's two subagents produced unwitnessed mechanisms, over-refusals and an abandoned mirror — so
-clean was not evidence of convergence**. Issue #63 is the opposite data point: both completed runs
+clean was not evidence of convergence**. TODO:269 is the second such data point: Codex returned
+clean in round 2, and **round 3 found a mechanism with no behavioural witness at all**. Issue #63 is the opposite data point: both completed runs
 returned real defects, both in subagent blind spots.
 
 **Practical proxies for "the remainder is bounded"** (so you can say it on the spot, not in

--- a/.claude/skills/metdsl-review-loop/references/sonnet-delegation.md
+++ b/.claude/skills/metdsl-review-loop/references/sonnet-delegation.md
@@ -1,6 +1,32 @@
 # Delegating verifiable review work to sonnet: the experiment log
 
-Four data points. SKILL.md carries the operational conclusion; this is the evidence, newest first.
+Five data points. SKILL.md carries the operational conclusion; this is the evidence, newest first.
+
+## Data point 5 (PR #88 / TODO:269, round 1) — the axis paid, and it pushed back on a false premise
+
+**Run as the delegated mechanical-recomputation axis** (the conclusion from data point 4), in
+parallel with two opus reviewers on other axes. 133k tok / 11 min, 50 tool uses.
+
+| | sonnet (mechanical) | opus (correctness+doc-truth) |
+|---|---|---|
+| real findings | 1 | 4 |
+| of which unique | 0 | 3 |
+| reported FALSE | 0 | 0 |
+
+**The one finding was the ruff count** (ledger said 3/1/7/2, actual 1/0/6/1), found independently
+by the opus reviewer as well — so on this branch the axis was **replaceable, not additive**. It
+also independently reproduced the mutation-check ledger and the two `git worktree` location
+artifacts, which is the cheap half of "verify the author's numbers" and freed the opus slots.
+
+**The result worth keeping is a different one: it refused a false premise I had put in its
+prompt.** I told it "the diff claims there are exactly 8 such readers"; that number came from my
+planning document, not the diff, which says 6. Rather than confabulating an 8-reader census it
+ran its own, reported 6, and wrote that it **could not find the claim I attributed to the diff**.
+That is the behaviour a mechanical axis needs most, and it is worth prompting for explicitly:
+**tell it to report claims it cannot locate rather than accounting for them.**
+
+Operationally: unchanged. Keep it as the mechanical axis, expect overlap rather than novelty, and
+do not read overlap as "no point" — the point is the freed up-model slot.
 
 ## Data point 4 (PR #72) — the confound resolved
 


### PR DESCRIPTION
Follow-up to #88. Dev-layer only — `.claude/skills/**` reaches no workflow leaf, and the
token ratchet does not read it.

Four rounds on #88 broke rules these skills already carry, and exposed **three gaps they
did not**. Only the gaps are added; the rules I broke that were already written, with the
right trigger point, are left alone.

## `metdsl-review-loop/SKILL.md`

**The numbers rule needed a new remedy.** The existing one — "keep a list of every place
you wrote a number and re-measure them together at the end" — fails outright once a review
loop starts, because **the end keeps moving**: answering a finding adds a test or a hunk,
so the act of fixing invalidates the ledger that describes the branch. On #88 one paragraph
rotted **three times, twice inside a commit whose stated purpose was to restate it**, and
reviewers reported the same two numbers in three consecutive rounds.

What stopped it was changing the **form**: every measurement written as a historical record
naming the commit it was taken at, with the property the count stands for stated beside it.
Also added: **a count with no unit is not reproducible** — "14 hunks" was reported as 19 and
as 16 by two reviewers before anyone noticed it depends on the diff context width (`-U0` /
`-U3` / `-U5` gave 21 / 17 / 15 on one range).

**A twin is the sharpest trigger for "one test per occurrence of a rule."** I built a
real-subprocess witness for exit code 4 and none for its twin exit code 3, in the same
commits, while adding three readers keyed on rc 3 plus a `--help` line and a RUNBOOK entry.
Mutating rc 3's mapping to `return 1` left **1555 rows green**, and three rounds walked past
it. The check is mechanical: list the pair, list your witnesses, compare the lists.

**A class docstring goes stale by ADDITION** — a mechanism distinct from the existing "a
test lies in its docstring" rule. The prose was true when written and became false when rows
were appended, in a class I had created **one round after renaming a sibling for exactly
that error**.

Plus a second data point for "Codex clean is not a stopping condition": clean in round 2,
and round 3 found a mechanism with no behavioural witness at all.

## `references/sonnet-delegation.md` — data point 5

Run as the delegated mechanical-recomputation axis. **Replaceable, not additive** here: its
one real finding (a wrong ruff count in the ledger) was also found by an opus reviewer. The
result worth keeping is different — **it refused a false premise I had put in its own
prompt**. I told it "the diff claims there are exactly 8 readers"; that number came from my
planning document, not the diff, which says 6. It ran its own census, reported 6, and wrote
that it could not find the claim I attributed to the diff. Worth prompting for explicitly.

## `metdsl-enforcement-change/references/verification.md`

**A new section for the backend-boundary token ratchet**, which had no coverage in this
reference at all and tripped **three times on #88, every time from ordinary prose**. It
reads whole files, so a commit verified only by its own module's test file will not see it —
one trip was caught two commits late that way, after a commit message had already asserted
"ratchet still green" without running it.

The section is mostly the judgement, which is the content that was missing:

- a **neutral-role citation** (naming a symbol the neutral core already exports) → regenerate
  and say so in the commit message;
- a **genuine addition** (a RUNBOOK entry spelling package names another module already owns
  and prints) → withdraw it, do not regenerate;
- **never rename an identifier to get under the counter** — a reviewer will point out that
  some growth was "avoidable by spelling", and taking that advice satisfies the instrument
  rather than the rule.

It also records that **a ratchet failure is a false KILL in a mutation sweep** (deleting an
identifier moves a count, so the mutant reads as killed for a reason unrelated to behaviour)
— which is exactly how the unwitnessed exit code stayed hidden for three rounds.

**`ruff check --statistics` is how you get a count.** Four numbers went into the ledger from
a counter written for the occasion whose pattern matched zero digits. The comparison itself
survived, because the same wrong counter ran on both sides — the shape that makes this kind
of bug last.

**One match expression is not a census.** Six documents stated one rule: reading and grepping
found 2; one `os.walk` expression found 5 and was written up as "the record of how many sites
there are"; a reviewer using different words from the same rule found the 6th. Run two or
three expressions built from different words and stop only when they agree.

## What I deliberately did NOT add

The orphaned-wait trap (`until ! pgrep -f "foo.py"` matching its own shell) and "prose you
newly write is unverified until you run it". I broke both on #88 — the first for 72 minutes.
Both are already written, at the right trigger point, and one of them says "this trap catches
me too". Adding more words to a rule I read and then ignored is not the fix.

## Verification

Suite 5064 passed / 0 failed on this branch and on `main` after #88 merged. Every number
quoted in the new skill text was measured directly during that work — the 1555-row mutant
survival, the 21/17/15 context-width counts, the 17-hunk / 10-killed final sweep, and the
sonnet run's 133k tokens / 11 min / 50 tool uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)