### PR TITLE
The mutation harness was reddening its own baseline, and round 0 had nothing to say about a docs-only diff

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/references/verification.md
+++ b/.claude/skills/metdsl-enforcement-change/references/verification.md
@@ -11,20 +11,20 @@ while developing this repository.
 ## The suite
 
 ```bash
-TMPDIR=/dev/shm python3 -m pytest tools/tests/ -q -p no:randomly
+python3 -m pytest tools/tests/ -q -p no:randomly
 ```
 
+- **Do NOT point `TMPDIR` at `/dev/shm`.** This section used to recommend it, and the
+  recommendation cost two false failures on `main` and on a branch alike (measured 2026-08-21):
+  `test_hooks_common.py::DevShmWriteBlockTests::test_blocks_dev_shm_via_find_traversal` and
+  `::test_blocks_dev_shm_via_tar_chdir`. Those two reason about a write guard over `/dev/shm`, so
+  putting the fixture's own scratch directory inside the path under test returns a different
+  policy id. It bought nothing either: `/tmp` is tmpfs here too, and four alternating full-suite
+  runs did not separate them (96.7 / 103.0 s against 102.3 / 93.8 s). **The rule, not the
+  spelling**: a scratch root must not be a path the suite makes assertions about. On a host whose
+  `/tmp` is disk-backed, point `TMPDIR` at some OTHER tmpfs
 - **Never run two of these in parallel.** They share `TMPDIR`, which produces false failures
   (hit for real once)
-- **`TMPDIR=/dev/shm` itself costs two false failures**, measured 2026-08-21 on `main` and on a
-  branch alike: `test_hooks_common.py::DevShmWriteBlockTests::test_blocks_dev_shm_via_find_traversal`
-  and `::test_blocks_dev_shm_via_tar_chdir`. Those two reason about a write guard over `/dev/shm`,
-  and pointing `TMPDIR` there puts the fixture's own scratch directory inside the path the guard
-  is being asked about, so the verdict comes back as a different policy id. Both pass with
-  `TMPDIR` unset. Same class as the `ForbidBackendCredentialReadTests` note below — an
-  environment-dependent pre-existing failure, not a finding — but this one is caused by the
-  command this section recommends, so a run that reports "2 failed" has said nothing until it
-  names WHICH two
 - The baseline is the measured value on `origin/main`. If you compare via `git worktree` /
   `git archive`, placing the checkout outside `$HOME` makes
   `test_hooks_common.py::ForbidBackendCredentialReadTests` fail (it assumes `../..` / `~`
@@ -142,7 +142,7 @@ below, which includes `phase_01_compile.md` and none of the other phase docs. **
 first**: editing a doc that is not in the table and running the command measures nothing.
 
 ```bash
-TMPDIR=/dev/shm python3 -m pytest tools/tests/test_orchestration_runtime.py -q -p no:randomly -k child_context_docs
+python3 -m pytest tools/tests/test_orchestration_runtime.py -q -p no:randomly -k child_context_docs
 ```
 
 If you exceed one, **cut redundancy rather than raising the ceiling**.

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -115,6 +115,17 @@ if you use it).
 The rules below are compact; `references/mutation-testing.md` carries the episodes each one
 came from, and the reasoning you need when a rule does not obviously apply.
 
+- **A red baseline is the HARNESS's fault before it is the suite's.** The script's own scratch
+  paths are inputs to the suite it runs: the per-job temp root (`$TMPDIR`) and the worktree
+  location (`--workdir`, whose filesystem DEPTH differs from your checkout's). A suite green in
+  your checkout and red under the harness is almost always one of those, and it is not a finding
+  about your change. Measured in met-dsl: the old `/dev/shm` temp-root default reddened the two
+  `DevShmWriteBlockTests` rows that reason about `/dev/shm`, and the default `--workdir` under
+  `~/.cache` reddens the hook rows that resolve `..` and `~` against the checkout — together they
+  made a full-suite `--test-cmd` impossible to run at all, while the message said "fix the suite".
+  The rule generalises past those two: **the harness's scratch paths must not be paths the suite
+  makes assertions about**, and nothing can know which those are for you. The BASELINE RED message
+  now names both levers; when it fires, try them before touching a test
 - **Pass `--continue-on-collection-errors` when a hunk comes back INCONCLUSIVE, and drop `-x`
   when you do.** A mutation can kill pytest during collection, and a scorer reading only `FAILED`
   lines records that as green (PR #68: 3 mutants hid 41-47 real failures). The two flags cancel:

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -126,6 +126,16 @@ came from, and the reasoning you need when a rule does not obviously apply.
   The rule generalises past those two: **the harness's scratch paths must not be paths the suite
   makes assertions about**, and nothing can know which those are for you. The BASELINE RED message
   now names both levers; when it fires, try them before touching a test
+- **A documentation-only diff reports every hunk as SURVIVED, and that is a MEASUREMENT, not a
+  failure.** It says no test observes any claim the branch makes, which for prose is usually
+  correct and occasionally not. Do not respond by pinning everything, and do not respond by
+  skipping round 0. Split the hunks: a claim that is **mechanically checkable** — a path that must
+  exist, a table column that must agree with `git`, a pointer that must be reachable — gets a
+  check; everything else is declared prose in the commit message, with the count. On the TODO:414
+  branch this turned 13 of 13 surviving into 5 killed plus 8 named as prose, and writing the
+  checks found an over-refusal before any reviewer saw the branch. **Beware the trap on the other
+  side**: a check that parses prose to decide what a claim IS will refuse correct writing, which
+  is the failure that took two rebuilds and a scope declaration to stop on that same branch
 - **Pass `--continue-on-collection-errors` when a hunk comes back INCONCLUSIVE, and drop `-x`
   when you do.** A mutation can kill pytest during collection, and a scorer reading only `FAILED`
   lines records that as green (PR #68: 3 mutants hid 41-47 real failures). The two flags cancel:

--- a/.claude/skills/metdsl-review-loop/references/mutation-testing.md
+++ b/.claude/skills/metdsl-review-loop/references/mutation-testing.md
@@ -11,6 +11,31 @@ scorer that reads only `FAILED` lines saw no failures and recorded them as kille
 `--continue-on-collection-errors` produced 41-47 real failures per mutant. Put the flag in your own
 scorer and in the reviewer's instructions.
 
+## The harness's own scratch paths reddened the baseline (TODO:414, 2026-08-21)
+
+Two of the script's defaults were themselves inputs to the suite under test, and together they
+made a full-suite `--test-cmd` impossible to run in met-dsl at all.
+
+- The per-job temp root defaulted to `/dev/shm`. Two rows of `DevShmWriteBlockTests` ask what the
+  write guard says about `/dev/shm`, so putting the job's scratch directory inside that path
+  returned a different policy id and the baseline came back red. Confirmed in both directions: any
+  `TMPDIR` under `/dev/shm` reddens exactly those two, a `TMPDIR` under `/tmp` does not.
+- With that fixed, the default `--workdir` (`~/.cache/mutation-check`) reddened
+  `ForbidBackendCredentialReadTests::test_blocks_bash_only_tilde_prefixes` instead: the worktree
+  sits at a different filesystem DEPTH from the checkout, and that row resolves `~+/../..` against
+  it. `--workdir` at the checkout's own depth clears it.
+
+What made the episode cost an hour rather than a minute is that the message said "Fix the suite
+(or narrow --test-cmd)" — pointing at the one thing that was not wrong. The suite was green in the
+checkout the whole time. **The script now names both levers in the BASELINE RED message**, and the
+temp root defaults to the platform's rather than to a path chosen for speed it did not deliver
+(`/tmp` was tmpfs on that host too; four alternating full-suite runs measured 96.7 / 103.0 s
+against 102.3 / 93.8 s — no separation).
+
+The transferable rule is not about those two paths. It is that **a harness which supplies paths to
+the code it measures has to assume some of them are under test**, and it cannot find out which
+from the inside. When a baseline is red, ask what the harness changed before asking what you did.
+
 ## A stale worktree makes every mutant look killed (PR #67)
 
 The script runs a baseline unless you pass `--skip-baseline`; handwriting has no baseline at all.

--- a/.claude/skills/metdsl-review-loop/references/mutation-testing.md
+++ b/.claude/skills/metdsl-review-loop/references/mutation-testing.md
@@ -36,6 +36,26 @@ The transferable rule is not about those two paths. It is that **a harness which
 the code it measures has to assume some of them are under test**, and it cannot find out which
 from the inside. When a baseline is red, ask what the harness changed before asking what you did.
 
+## A documentation-only diff surviving in full is a measurement (TODO:414, 2026-08-21)
+
+A branch whose diff is prose reports every hunk SURVIVED. Read literally that is true and useful:
+no test observes any claim the branch makes. It is not a reason to skip round 0, and not a reason
+to pin everything either.
+
+What worked: split the hunks by whether the claim is **mechanically checkable**. A path that must
+exist, a table column that must agree with `git ls-files` / `git check-ignore`, a pointer that
+must be reachable from a document an agent always reads — those get a check. Everything else is
+declared prose in the commit message, with a count, so the survivor list is a classification
+rather than a debt. On that branch it moved 13 of 13 surviving to 5 killed plus 8 declared, and
+writing the checks surfaced an over-refusal before a reviewer saw the branch.
+
+The counter-lesson from the same branch matters as much: the FIRST attempt at those checks parsed
+markdown prose to decide what a citation was, and two successive versions were broken by reviewers
+in the same way — thirteen refusals of correct writing between them. Checks over a documentation
+diff should key on STRUCTURE the format guarantees (a table with a separator row, a header cell, a
+list entry) and never on prose. When the second version breaks the way the first did, that is the
+signal to declare the scope and stop, not to write a third.
+
 ## A stale worktree makes every mutant look killed (PR #67)
 
 The script runs a baseline unless you pass `--skip-baseline`; handwriting has no baseline at all.

--- a/.claude/skills/metdsl-review-loop/scripts/mutation_check.py
+++ b/.claude/skills/metdsl-review-loop/scripts/mutation_check.py
@@ -12,8 +12,17 @@ this with a mechanism-level deletion and with checking that each fixture has onl
 to the outcome it asserts. See the skill's "Before you hand it over (round 0)".
 
 The checkout is never touched: every mutation happens in a `git worktree` under
-`--workdir` (default `~/.cache/mutation-check`). Keeping it under $HOME matters for
-met-dsl, where a few hook tests are sensitive to the checkout's filesystem depth.
+`--workdir` (default `~/.cache/mutation-check`), with one scratch root per job under
+`$TMPDIR` (default: the platform's).
+
+**Both of those are paths the harness chooses, and a suite can be red because of them
+rather than because of your change.** In met-dsl the default worktree location has a
+different filesystem DEPTH from the checkout, which reddens the hook tests that resolve
+`..` and `~`; and a scratch root under `/dev/shm` reddens the two tests that reason about
+a write guard over `/dev/shm`. The BASELINE RED message names both levers. The rule behind
+them: the harness's scratch paths must not be paths the suite makes assertions about, and
+this script cannot know which those are — so when the baseline is red, suspect the harness
+before the suite.
 
     python3 mutation_check.py --range HEAD~1..HEAD --paths mcp_servers tools \\
         --test-cmd "python3 -m pytest tools/tests/test_build_runtime_server.py -q -x"
@@ -343,7 +352,12 @@ def main() -> int:
                          "output is read only to tell a real failure from a suite that never "
                          "ran, so pass -x (pytest) to stop at the first failure")
     ap.add_argument("--repo", default=".", help="repository (default: cwd)")
-    ap.add_argument("--workdir", default=str(Path.home() / ".cache" / "mutation-check"))
+    ap.add_argument("--workdir", default=str(Path.home() / ".cache" / "mutation-check"),
+                    help="where the throwaway worktrees go. The default keeps them under "
+                         "$HOME, which matters where hook tests resolve `~`; it does NOT "
+                         "match your checkout's DEPTH, and a test that resolves `..` "
+                         "against it can turn the baseline red. Point this at a directory "
+                         "at the same depth as your checkout when that happens")
     ap.add_argument("--timeout", type=int, default=1800)
     ap.add_argument("--jobs", type=int, default=0,
                     help="hunks to test at once, each in its own worktree "
@@ -423,7 +437,20 @@ def main() -> int:
     # One TMPDIR per job, since concurrent jobs would otherwise share the temp root.
     # Named as short as `mkdtemp` allows: a met-dsl test asserts a budget on a message
     # that carries a temp path, and a long temp root alone can fail it.
-    tmp_base = os.environ.get("TMPDIR", "/dev/shm")
+    #
+    # `gettempdir()`, which honours TMPDIR and falls back to the platform default. It used
+    # to default to `/dev/shm`, and that default made this script UNUSABLE with a full-suite
+    # `--test-cmd` in met-dsl: two `DevShmWriteBlockTests` rows reason about a write guard
+    # over `/dev/shm`, so putting the job's scratch root inside the path under test made the
+    # BASELINE red on every run — and the message then told the operator to fix a suite that
+    # is green in their own checkout. The general rule the episode teaches: **the harness's
+    # own scratch root must not be a path the suite makes assertions about**, and there is no
+    # way to know which path that is from here, so the default is the one the platform already
+    # chose. `/dev/shm` bought nothing anyway where it was measured — `/tmp` was tmpfs there
+    # too, and four alternating full-suite runs did not separate them (96.7 / 103.0 s against
+    # 102.3 / 93.8 s). On a host where `/tmp` is disk-backed, point TMPDIR at a tmpfs of your
+    # choosing rather than assuming this one.
+    tmp_base = os.environ.get("TMPDIR") or tempfile.gettempdir()
     tmpdirs = {wt: Path(tempfile.mkdtemp(prefix="m", dir=tmp_base)) for wt in worktrees}
     free: list[Path] = list(worktrees)
     lock = threading.Lock()
@@ -503,9 +530,18 @@ def main() -> int:
             elif base.returncode:
                 print("BASELINE RED — the suite fails with nothing reverted, so every "
                       "hunk would report 'killed' for a reason that is not the hunk.\n"
-                      "Fix the suite (or narrow --test-cmd) and rerun. A suite that is "
-                      "green in the checkout but red here is usually reading its own "
-                      "path: the worktree and TMPDIR differ. Last lines:\n")
+                      "BEFORE fixing the suite, check whether THIS HARNESS caused it: a "
+                      "suite green in your checkout and red here is reading a path this "
+                      "run chose, not one your change made. Two levers, both this "
+                      "script's:\n"
+                      f"  * the per-job scratch root is {tmp_base} — if any test reasons "
+                      "about that path, set TMPDIR to somewhere else and rerun;\n"
+                      f"  * the worktrees are under {args.workdir}, so their filesystem "
+                      "DEPTH differs from your checkout's — a test that resolves `..` or "
+                      "`~` relative to the checkout answers differently. Pass --workdir "
+                      "with a directory at your checkout's own depth.\n"
+                      "If neither is it, fix the suite (or narrow --test-cmd) and rerun. "
+                      "Last lines:\n")
                 print("\n".join((base.stdout + base.stderr).splitlines()[-25:]))
                 baseline_failed = True
             else:

--- a/tools/tests/test_mutation_check.py
+++ b/tools/tests/test_mutation_check.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import tempfile
 import sys
 import unittest
 from pathlib import Path
@@ -637,6 +638,68 @@ class MutationCheckScenarioTests(unittest.TestCase):
         run = self.run_check(test_cmd=f"{sys.executable} -c \"raise SystemExit(1)\"")
         self.assertIn("BASELINE RED", run.out, msg=str(run))
         self.assertEqual(2, run.code, msg=str(run))
+
+    def test_a_red_baseline_names_the_two_paths_this_harness_chose(self) -> None:
+        """The message must accuse the HARNESS before the suite.
+
+        Both of these defaults were once inputs to met-dsl's own suite — a `/dev/shm` scratch
+        root reddened the two tests that reason about `/dev/shm`, and the default worktree
+        location reddens the hook tests that resolve `..` against the checkout's depth. The
+        message said "Fix the suite", which is the one thing that was not wrong, so a full-suite
+        `--test-cmd` looked impossible to run. What is pinned is that both levers are NAMED with
+        their live values, not the wording around them.
+        """
+        self.repo.write("k.py", "x = 1\n")
+        self.repo.commit("base")
+        self.repo.write("k.py", "x = 2\n")
+        self.repo.commit("change")
+        run = self.run_check(test_cmd=f"{sys.executable} -c \"raise SystemExit(1)\"")
+        self.assertIn("BASELINE RED", run.out, msg=str(run))
+        self.assertIn("TMPDIR", run.out, msg=str(run))
+        # Each lever asserted as ONE span joining its wording to its live value. Asserting the
+        # two separately passed for the wrong reason: the run's first line already prints the
+        # worktree root, so deleting the lever sentence left the assertion satisfied.
+        self.assertIn(f"scratch root is {self.tmp}", run.out,
+                      msg="the scratch root in force is not named by the message")
+        self.assertIn(f"worktrees are under {self.workdir}", run.out,
+                      msg="the worktree root in force is not named by the message")
+        self.assertIn("DEPTH differs", run.out, msg=str(run))
+
+    def test_the_scratch_root_falls_back_to_the_platform_not_to_dev_shm(self) -> None:
+        """With TMPDIR unset, the root is `tempfile.gettempdir()`.
+
+        Read out of the red-baseline message, which is the only place the script publishes it.
+        The default used to be `/dev/shm` unconditionally, and a scratch root must not be a path
+        the suite under test makes assertions about — which the script cannot know, so it takes
+        the platform's answer rather than choosing one for speed it did not deliver.
+        """
+        self.repo.write("k.py", "x = 1\n")
+        self.repo.commit("base")
+        self.repo.write("k.py", "x = 2\n")
+        self.repo.commit("change")
+        env = {k: v for k, v in os.environ.items() if k != "TMPDIR"}
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--range", "HEAD~1..HEAD",
+             "--test-cmd", f"{sys.executable} -c \"raise SystemExit(1)\"",
+             "--jobs", "1", "--workdir", str(self.workdir)],
+            cwd=self.repo.root, text=True, capture_output=True,
+            env={**env, **_NO_GIT_CONFIG})
+        out = proc.stdout + proc.stderr
+        self.assertIn("BASELINE RED", out, msg=out[-2000:])
+        self.assertIn(f"scratch root is {tempfile.gettempdir()}", out, msg=out[-2000:])
+        self.assertNotIn("/dev/shm", out, msg=out[-2000:])
+
+    def test_the_workdir_help_says_its_depth_is_load_bearing(self) -> None:
+        """A reader who hits the depth failure looks at `--help` before the source."""
+        proc = subprocess.run([sys.executable, str(SCRIPT), "--help"],
+                              text=True, capture_output=True)
+        # The REMEDY, not the word `DEPTH`: the help says "does NOT match your checkout's
+        # DEPTH" a sentence earlier, so asserting the word alone was satisfied by the
+        # diagnosis while the instruction that fixes it could be deleted unnoticed.
+        # Whitespace collapsed: argparse re-wraps help text, so the phrase is split across
+        # lines at a width nobody controls.
+        flattened = " ".join(proc.stdout.split())
+        self.assertIn("same depth as your checkout", flattened, msg=proc.stdout)
 
     def test_a_baseline_that_times_out_exits_two_without_a_traceback(self) -> None:
         self.repo.write("k.py", "x = 1\n")


### PR DESCRIPTION
**Depends on #90** — this branch is stacked on it, so the diff below is `06f3675..HEAD` (three commits). Merge #90 first.

Both changes come from *using* the review tooling on #90 rather than from reading it.

## 1. The mutation harness was reddening the baseline and blaming the suite

A full-suite `--test-cmd` could not be run at all with the documented invocation, and the failure message pointed at the one thing that was not wrong. Two of the script's own defaults were inputs to the suite it measures:

| default | what it broke | measured |
|---|---|---|
| per-job scratch root `/dev/shm` | the two `DevShmWriteBlockTests` rows that ask what the write guard says about `/dev/shm` | any `TMPDIR` under `/dev/shm` reddens exactly those two; one under `/tmp` does not |
| `--workdir` = `~/.cache/mutation-check` | `ForbidBackendCredentialReadTests::test_blocks_bash_only_tilde_prefixes` — the worktrees sit at a different filesystem DEPTH from the checkout, and that row resolves `~+/../..` against it | reproduced, and cleared by `--workdir` at the checkout's own depth |

With both in force the baseline was red on every run while the suite was green in the checkout, and the message said *"Fix the suite (or narrow --test-cmd)"*.

**The temp root now defaults to the platform's** (`tempfile.gettempdir()`, which honours `TMPDIR`). `/dev/shm` bought nothing where it was measured — `/tmp` is tmpfs on that host too, and four alternating full-suite runs did not separate them (96.7 / 103.0 s against 102.3 / 93.8 s). On a host whose `/tmp` is disk-backed, point `TMPDIR` at another tmpfs.

**The BASELINE RED message now accuses the harness first**, naming both levers with their live values, and `--workdir`'s help says its depth is load-bearing and what to do about it. Verified: the harness completes a full-suite run against this repository with `--workdir` alone.

The rule the episode teaches, which is what the skill and the docstring carry rather than the two paths: **a harness that supplies paths to the code it measures must assume some of them are under test, and it cannot learn which from the inside.** `references/verification.md` stops recommending `TMPDIR=/dev/shm` in both places it appeared, for the same reason.

## 2. Round 0 had no guidance for a documentation-only diff

#90's round 0 reported 13 of 13 hunks surviving, and neither reading of that is right alone: it is not a failure (for prose, "no test observes this claim" is usually correct) and not a reason to skip round 0 (some of those claims were mechanically checkable and none were checked).

The rule added: split the hunks by whether the claim can be checked without judgement — a path that must exist, a table column that must agree with `git`, a pointer that must be reachable — and declare the rest prose in the commit message, with the count, so the survivor list is a classification rather than a debt. On #90 that moved 13 of 13 surviving to 5 killed plus 8 declared, and writing the checks surfaced an over-refusal before any reviewer saw the branch.

The counter-lesson ships with it because it cost more than the rule saved: #90's first attempt at those checks parsed markdown prose to decide what a citation was, and two successive versions were broken the same way — thirteen refusals of correct writing between them. A check over a documentation diff keys on STRUCTURE the format guarantees, never on prose; and when the second version breaks the way the first did, that is the signal to declare the scope, not to write a third.

## Verification

- `python3 -m pytest tools/tests/ -q -p no:randomly` — **5092 passed, 0 failed**.
- `tools/tests/test_mutation_check.py` gains three tests, because its own suite sets `TMPDIR` explicitly and so never took the default branch, and only the string `BASELINE RED` was pinned. **Five mutants, one at a time, all killed**: the `/dev/shm` default restored, each of the two levers deleted, the depth explanation deleted, the help remedy deleted.
- **Two of those three witnesses passed for the wrong reason when first written**, and mutating is what found it: asserting the workdir path and the lever wording separately was satisfied by the run's own first line, which already prints the worktree root; and asserting the word `DEPTH` in `--help` was satisfied by the sentence that diagnoses the problem while the one that fixes it could be deleted unnoticed. Both are now single assertions joining wording to value.
- The harness was run against this branch with the new defaults and completed.
