### PR TITLE
Teach the two review skills what issue #71 proved they were missing

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/SKILL.md
+++ b/.claude/skills/metdsl-enforcement-change/SKILL.md
@@ -132,34 +132,52 @@ emitted** 40 lines below stayed stale. Worse, the "measured value" I cited as gr
 inverted by an implementation change (the consequence of `language: " fortran"`). Use the grep
 procedure in `references/verification.md`.
 
-**3-a. Past three statement sites, the sweep is not enough — COUPLE the documents to the rule
-with a check.** Rule 3 is a discipline, and on issue #71 that discipline failed **four
-consecutive rounds after it had been diagnosed**. Round 11 named "the rounds were reliable
-about code and unreliable about their own record"; rounds 12, 13, 14 and 15 each found the
-same class again. The worst instance: the hook refuses on `pattern.startswith(("/", "~"))`,
-and **five canonical statements said "ONLY when it is ABSOLUTE"** — `~` is not absolute, which
-was that branch's own central measurement — so `docs/AGENT_CONTRACT.md`, **the only document a
-leaf reads**, told a leaf that a refusal it can actually receive cannot happen. Round 14
-corrected the refusal string and propagated it to none of the five.
+**3-a. When the sweep keeps losing, COUPLE the documents to the rule with a check.** Rule 3
+is a discipline, and on issue #71 it failed **four consecutive rounds after it had been
+diagnosed**: round 11 named "the rounds were reliable about code and unreliable about their own
+record", and rounds 12 through 15 each CARRIED the same class — carried, not found: round 12 is the
+narrowing commit and discovered no record defect, so "four rounds found it" would overstate what
+the history shows. The worst instance: the hook
+refuses a `Glob` pattern beginning with `/` or with `~`, and **five canonical statements said
+"ONLY when it is ABSOLUTE"** — `~` is not absolute, which was that branch's own central
+measurement — so `docs/AGENT_CONTRACT.md`, the one document EVERY leaf reads, told a leaf that
+a refusal it can actually receive cannot happen.
 
-What ended it was not more care. It was a test that **reads the rule's constant out of the
-code** and requires every statement site to name every member, so adding a prefix fails until
-the documents say so:
+**Reach for the pattern this repository already uses three times** rather than inventing one:
+`tools/tests/test_hooks_cli.py` holds `_SCRATCH_SURFACES`, `_REDIRECT_RULE_SURFACES` and
+`_SURFACES` — a table of `(file, anchor)` pairs, a bounded reader, and a requirement over what
+each anchored statement must contain. Copy the nearest one. Its three traps, each of which cost
+a round:
 
-- **The rule is defined once, in the code, and the documents are checked against it.** Not the
-  reverse, and not both spelled out independently — two independent spellings is the defect
 - **Anchor on text that PRECEDES the rule and is byte-identical in the wording you are
-  refusing.** My first draft anchored on my own corrected sentence, so restoring the true
-  pre-fix wording failed with "the anchor is missing" — it pinned that my correction survived,
-  not that the rule is stated. Witness the check by restoring the old wording and confirming
-  the failure names the missing member
-- **Bound the reader and self-test the bound.** `docs/HOOKS.md` names `~` several times in its
-  MEASUREMENT list on the same line whose RULE sentence said "absolute"; a whole-file window
-  would have called that file correct
-- The trigger for reaching for this: **count the places that state the rule.** At three or more,
-  or when one of them is read by a leaf or an operator, discipline has already lost. This is the
-  documentation twin of surface 5's "at three or more sites, change the channel design instead
-  of fixing them individually"
+  refusing.** Anchoring on your own corrected sentence pins that the correction survived, not
+  that the rule is stated — witness the check by restoring the old wording and confirming the
+  failure names what is missing, not the anchor
+- **Bound the reader and self-test the bound**, or a document that mentions the rule's terms
+  anywhere passes on the strength of an unrelated sentence
+- **Decide what "names the rule" means for THIS rule.** Couple by MEMBERS only when the prose
+  names them in full — a two-element trigger, yes; a nineteen-entry environment allowlist,
+  never, because the documents state that policy abstractly and correctly. Otherwise couple by
+  POINTER (each site must cite where the constant lives) or by NUMBER. Pin the members, not the
+  source line: a legitimate extraction to a named constant must not turn a true statement red
+
+**Before adding a check, ask whether the sites should exist.** The cheaper fix is this
+repository's ordinary practice — one canonical statement, everyone else cites it (`AGENTS.md`
+§Dedicated rule documents) — and it cannot rot. Coupling is for the sites that must repeat the
+rule anyway: a leaf-read contract has to be self-contained, and a refusal message has to say it
+to whoever was refused. Note this is NOT surface 5's twin, though both count to three: surface
+5 changes the design so there is one site, and 3-a adds machinery so that many sites stay
+honest. Prefer surface 5's move whenever it is available.
+
+**The trigger is the count; the audience is the priority.** Three or more statement sites is
+when discipline has already lost. That one of them is read by a leaf or an operator does not
+lower the count — it decides how soon you do it, and which site you check first.
+
+**Sites a test cannot reach are real and the check does not cover them**: commit messages and
+PR bodies (which cannot be edited), issue text, a prompt assembled at runtime, and
+`docs/examples/*.yaml`, which this repository has recorded as untested and therefore
+permanently drifting. For those the only moves are to remove the statement or to make it
+derived. Say in the commit which sites you could not couple.
 
 **The flip side of 3: prose you newly write in that same commit is also unverified until you
 run it.** Read rule 3 as being about old text and you keep only half of it. In L128 I got
@@ -309,29 +327,6 @@ pinning the range and the class **name** → now the class's **branches** were w
 **Rule**: never let a pin and the command with authority to loosen it **live in the same file
 or the same procedure**. And pin the rule, not the result the rule produced (pinning results
 makes ordinary work fail and teaches the habit of regenerating without reading the rule).
-
-**Two more questions about the same sentence, both of which cost real consequence on issue
-#71.** Surface 6 above asks what the remedy REWRITES. Ask also what it MEANS to the person who
-follows it, because a remedy is the one piece of a gate that is executed by a human or a leaf
-rather than by code:
-
-- **Can it be followed by half?** The `Glob` refusal ended "Re-issue it against a granted
-  directory, or drop the leading `/` and pass the directory as `path`." That reads as two
-  options. A leaf doing only the first half is **allowed by the hook** (rc=0, measured) and the
-  tool then matches nothing, because a relative pattern is anchored at the repository root
-  while the search is confined to `path`. No refusal, no log line, nothing below that could
-  produce one — the leaf reports "the files are not there". **Silent empty is the worst answer
-  a read boundary can give**, because it is indistinguishable from a true negative. When a
-  remedy is a conjunction, say so, and say what doing one half produces
-- **Does it name the most REACHABLE cause first?** The roster check's `missing` remedy said
-  "for a built-in the CLI stopped offering, record it in `CLAUDE_LEAF_TOOLS_ABSENT_ON_CLI`" —
-  a vendor cause. But the probe deliberately seeds the committed leaf configuration, and a
-  `permissions.deny` there removes the tool, so **a local one-line edit was the shortest path
-  to that failure** and was the one cause the remedy omitted. Following the printed remedy
-  subtracts the tool from the required set permanently: **the check goes green by having been
-  WIDENED rather than satisfied**. Enumerate the ways the failure can be produced, order them
-  by reachability, and let the printed remedy follow that order. A remedy whose first move
-  loosens the check is the same defect as surface 6's regenerate command, delivered as prose
 
 **Surface 7: when you say you closed a configuration surface, what else does that tool read
 besides configuration files?** The six above are about inputs reaching a gate; this one is
@@ -505,6 +500,20 @@ cannot converge in principle**, handed back to the leaf (flagged two rounds runn
   program unit rather than the actual cause). Do not let it read as "the cause is here"
 - If the enumeration does not close, **say so and describe the shape to look for** ("an
   identifier or label sits where the parser expects structure")
+- **Order the causes by REACHABILITY, most reachable first.** Issue #71's roster check offered
+  a vendor cause ("the CLI stopped offering this tool, record it in the absent-on-CLI seam")
+  when the shortest path to that failure was a one-line `permissions.deny` in the leaf
+  configuration the probe itself seeds. Following the printed remedy subtracts the tool from
+  the required set permanently: **the check goes green by having been WIDENED rather than
+  satisfied**, which is surface 6's regenerate command delivered as prose
+- **A remedy must not be followable by HALF.** The same branch's `Glob` refusal ended
+  "Re-issue it against a granted directory, or drop the leading `/` and pass the directory as
+  `path`" — read as two options. A leaf doing only the first half is ALLOWED by the hook (rc=0,
+  measured) and the tool then matches nothing, because a relative pattern is anchored at the
+  repository root while the search is confined to `path`. No refusal, no log line, nothing
+  below that could produce one. **Silent empty is the worst answer a boundary can give**: it is
+  indistinguishable from a true negative, so the leaf reports absence and stops. When a remedy
+  is a conjunction, say so, and say what doing one half produces
 
 ### 4. Tests pin properties
 

--- a/.claude/skills/metdsl-enforcement-change/SKILL.md
+++ b/.claude/skills/metdsl-enforcement-change/SKILL.md
@@ -132,6 +132,35 @@ emitted** 40 lines below stayed stale. Worse, the "measured value" I cited as gr
 inverted by an implementation change (the consequence of `language: " fortran"`). Use the grep
 procedure in `references/verification.md`.
 
+**3-a. Past three statement sites, the sweep is not enough — COUPLE the documents to the rule
+with a check.** Rule 3 is a discipline, and on issue #71 that discipline failed **four
+consecutive rounds after it had been diagnosed**. Round 11 named "the rounds were reliable
+about code and unreliable about their own record"; rounds 12, 13, 14 and 15 each found the
+same class again. The worst instance: the hook refuses on `pattern.startswith(("/", "~"))`,
+and **five canonical statements said "ONLY when it is ABSOLUTE"** — `~` is not absolute, which
+was that branch's own central measurement — so `docs/AGENT_CONTRACT.md`, **the only document a
+leaf reads**, told a leaf that a refusal it can actually receive cannot happen. Round 14
+corrected the refusal string and propagated it to none of the five.
+
+What ended it was not more care. It was a test that **reads the rule's constant out of the
+code** and requires every statement site to name every member, so adding a prefix fails until
+the documents say so:
+
+- **The rule is defined once, in the code, and the documents are checked against it.** Not the
+  reverse, and not both spelled out independently — two independent spellings is the defect
+- **Anchor on text that PRECEDES the rule and is byte-identical in the wording you are
+  refusing.** My first draft anchored on my own corrected sentence, so restoring the true
+  pre-fix wording failed with "the anchor is missing" — it pinned that my correction survived,
+  not that the rule is stated. Witness the check by restoring the old wording and confirming
+  the failure names the missing member
+- **Bound the reader and self-test the bound.** `docs/HOOKS.md` names `~` several times in its
+  MEASUREMENT list on the same line whose RULE sentence said "absolute"; a whole-file window
+  would have called that file correct
+- The trigger for reaching for this: **count the places that state the rule.** At three or more,
+  or when one of them is read by a leaf or an operator, discipline has already lost. This is the
+  documentation twin of surface 5's "at three or more sites, change the channel design instead
+  of fixing them individually"
+
 **The flip side of 3: prose you newly write in that same commit is also unverified until you
 run it.** Read rule 3 as being about old text and you keep only half of it. In L128 I got
 **four newly written measurements or citations wrong inside the fix itself**:
@@ -280,6 +309,29 @@ pinning the range and the class **name** → now the class's **branches** were w
 **Rule**: never let a pin and the command with authority to loosen it **live in the same file
 or the same procedure**. And pin the rule, not the result the rule produced (pinning results
 makes ordinary work fail and teaches the habit of regenerating without reading the rule).
+
+**Two more questions about the same sentence, both of which cost real consequence on issue
+#71.** Surface 6 above asks what the remedy REWRITES. Ask also what it MEANS to the person who
+follows it, because a remedy is the one piece of a gate that is executed by a human or a leaf
+rather than by code:
+
+- **Can it be followed by half?** The `Glob` refusal ended "Re-issue it against a granted
+  directory, or drop the leading `/` and pass the directory as `path`." That reads as two
+  options. A leaf doing only the first half is **allowed by the hook** (rc=0, measured) and the
+  tool then matches nothing, because a relative pattern is anchored at the repository root
+  while the search is confined to `path`. No refusal, no log line, nothing below that could
+  produce one — the leaf reports "the files are not there". **Silent empty is the worst answer
+  a read boundary can give**, because it is indistinguishable from a true negative. When a
+  remedy is a conjunction, say so, and say what doing one half produces
+- **Does it name the most REACHABLE cause first?** The roster check's `missing` remedy said
+  "for a built-in the CLI stopped offering, record it in `CLAUDE_LEAF_TOOLS_ABSENT_ON_CLI`" —
+  a vendor cause. But the probe deliberately seeds the committed leaf configuration, and a
+  `permissions.deny` there removes the tool, so **a local one-line edit was the shortest path
+  to that failure** and was the one cause the remedy omitted. Following the printed remedy
+  subtracts the tool from the required set permanently: **the check goes green by having been
+  WIDENED rather than satisfied**. Enumerate the ways the failure can be produced, order them
+  by reachability, and let the printed remedy follow that order. A remedy whose first move
+  loosens the check is the same defect as surface 6's regenerate command, delivered as prose
 
 **Surface 7: when you say you closed a configuration surface, what else does that tool read
 besides configuration files?** The six above are about inputs reaching a gate; this one is

--- a/.claude/skills/metdsl-enforcement-change/SKILL.md
+++ b/.claude/skills/metdsl-enforcement-change/SKILL.md
@@ -143,11 +143,14 @@ refuses a `Glob` pattern beginning with `/` or with `~`, and **five canonical st
 measurement — so `docs/AGENT_CONTRACT.md`, the one document EVERY leaf reads, told a leaf that
 a refusal it can actually receive cannot happen.
 
-**Reach for the pattern this repository already uses three times** rather than inventing one:
+**Reach for the pattern this repository already uses three times** rather than inventing one.
 `tools/tests/test_hooks_cli.py` holds `_SCRATCH_SURFACES`, `_REDIRECT_RULE_SURFACES` and
-`_SURFACES` — a table of `(file, anchor)` pairs, a bounded reader, and a requirement over what
-each anchored statement must contain. Copy the nearest one. Its three traps, each of which cost
-a round:
+`_SURFACES` — but they are three DIFFERENT shapes, so read the one nearest your rule before
+copying it: `_SURFACES` is `(file, anchor)`; `_SCRATCH_SURFACES` is `(file, anchor, scope)` and
+that third column IS the bound; `_REDIRECT_RULE_SURFACES` has no anchor at all and couples by a
+phrase regex over a paragraph. **They also duplicate each other** — two near-identical
+anchored-window readers with two different window constants live in that one file — so copying
+is the starting point and not the goal. The three traps, each of which cost a round:
 
 - **Anchor on text that PRECEDES the rule and is byte-identical in the wording you are
   refusing.** Anchoring on your own corrected sentence pins that the correction survived, not
@@ -156,28 +159,38 @@ a round:
 - **Bound the reader and self-test the bound**, or a document that mentions the rule's terms
   anywhere passes on the strength of an unrelated sentence
 - **Decide what "names the rule" means for THIS rule.** Couple by MEMBERS only when the prose
-  names them in full — a two-element trigger, yes; a nineteen-entry environment allowlist,
-  never, because the documents state that policy abstractly and correctly. Otherwise couple by
-  POINTER (each site must cite where the constant lives) or by NUMBER. Pin the members, not the
-  source line: a legitimate extraction to a named constant must not turn a true statement red
+  names them in full — a two-element trigger, yes; `LEAF_ENV_ALLOWLIST`, never, because its
+  documents state the policy ("the environment is a declared allowlist") and correctly do not
+  enumerate it. Otherwise couple by POINTER (each site must cite where the constant lives) or
+  by NUMBER. **The rule is defined once, IN THE CODE, and the documents are checked against it**
+  — never the reverse, and never both spelled out independently, which is two spellings of one
+  rule and the defect this whole section is about
+- **Pin the members, not the source line.** A legitimate extraction to a named constant must
+  not turn a true statement red — and the exemplar above FAILS this: `_trigger_prefixes` reads
+  `pattern.startswith((…))` with a regex, so replacing the inline literal with a named constant
+  raises its assertion. Resolve a named constant before giving up, and make the failure name
+  the repair. This is the trap that is easiest to reintroduce, because pinning the spelling is
+  three lines and pinning the members is fifteen
 
 **Before adding a check, ask whether the sites should exist.** The cheaper fix is this
 repository's ordinary practice — one canonical statement, everyone else cites it (`AGENTS.md`
 §Dedicated rule documents) — and it cannot rot. Coupling is for the sites that must repeat the
 rule anyway: a leaf-read contract has to be self-contained, and a refusal message has to say it
 to whoever was refused. Note this is NOT surface 5's twin, though both count to three: surface
-5 changes the design so there is one site, and 3-a adds machinery so that many sites stay
-honest. Prefer surface 5's move whenever it is available.
+5 changes the CHANNEL a decision travels on so the decision stops being forgeable, and 3-a adds
+machinery so that many statements of one rule stay honest. Different question, same threshold.
 
 **The trigger is the count; the audience is the priority.** Three or more statement sites is
 when discipline has already lost. That one of them is read by a leaf or an operator does not
 lower the count — it decides how soon you do it, and which site you check first.
 
-**Sites a test cannot reach are real and the check does not cover them**: commit messages and
-PR bodies (which cannot be edited), issue text, a prompt assembled at runtime, and
-`docs/examples/*.yaml`, which this repository has recorded as untested and therefore
-permanently drifting. For those the only moves are to remove the statement or to make it
-derived. Say in the commit which sites you could not couple.
+**Sites a test cannot reach are real and the check does not cover them**: a commit message,
+which cannot be edited once pushed, and a prompt assembled at runtime. For those the only moves
+are to remove the statement or to make it derived; say in the commit which sites you could not
+couple. **Check before assuming a site is out of reach** — an issue or PR body can be edited
+(`gh issue edit --body`), and `docs/examples/*.yaml` was untested and permanently drifting until
+`tools/tests/test_llm_config.py` closed it, so citing that as a live example of the unreachable
+sends a reader past a site that is already coupled.
 
 **The flip side of 3: prose you newly write in that same commit is also unverified until you
 run it.** Read rule 3 as being about old text and you keep only half of it. In L128 I got
@@ -327,6 +340,11 @@ pinning the range and the class **name** → now the class's **branches** were w
 **Rule**: never let a pin and the command with authority to loosen it **live in the same file
 or the same procedure**. And pin the rule, not the result the rule produced (pinning results
 makes ordinary work fail and teaches the habit of regenerating without reading the rule).
+
+This surface asks what a remedy REWRITES. **A remedy is also READ, by a person or a leaf**, and
+the two rules for that — order the causes by reachability, and never let it be followable by
+half — are in §3 "Decide the failure's attribution", because they are about the message a
+failure hands back. Open both when you write one.
 
 **Surface 7: when you say you closed a configuration surface, what else does that tool read
 besides configuration files?** The six above are about inputs reaching a gate; this one is
@@ -500,7 +518,9 @@ cannot converge in principle**, handed back to the leaf (flagged two rounds runn
   program unit rather than the actual cause). Do not let it read as "the cause is here"
 - If the enumeration does not close, **say so and describe the shape to look for** ("an
   identifier or label sits where the parser expects structure")
-- **Order the causes by REACHABILITY, most reachable first.** Issue #71's roster check offered
+- **Order the causes by REACHABILITY, most reachable first** — this one is not only about a
+  leaf: it applies to any remedy a check prints, an operator's included, and it is surface 6's
+  question asked of the message instead of the command. Issue #71's roster check offered
   a vendor cause ("the CLI stopped offering this tool, record it in the absent-on-CLI seam")
   when the shortest path to that failure was a one-line `permissions.deny` in the leaf
   configuration the probe itself seeds. Following the printed remedy subtracts the tool from

--- a/.claude/skills/metdsl-enforcement-change/references/verification.md
+++ b/.claude/skills/metdsl-enforcement-change/references/verification.md
@@ -49,6 +49,24 @@ python3 -m pytest tools/tests/ -q -p no:randomly
   version of this line claimed one permanent calibration skip and sent a reader hunting a test that
   does not exist
 
+## Two ways a verification step silently does not run
+
+Both were hit on issue #71, and both look exactly like a passing step.
+
+**`cmd | tail && git commit` does not gate on `cmd`.** A pipeline exits with the status of its
+LAST element, so `python3 -m pytest … | tail -3 && git commit` commits whatever pytest did — the
+`&&` is inert and the summary line scrolls past in the same output that reports success. It put a
+commit on top of a red suite. Either run the command bare and read the code (`python3 -m pytest …
+-q; echo $?`), or put the guard on the command itself and pipe afterwards
+(`set -o pipefail` also fixes it, but only if the shell honours it — check rather than assume).
+
+**`git worktree add -C <repo> <name>` resolves `<name>` against the repository, not your cwd.**
+`-C` changes directory before running, so a relative path meant for a scratch directory creates
+the worktree INSIDE the checkout, and the next `git add -A` commits it as a gitlink — git warns,
+in a hint block that is easy to scroll past, and the commit succeeds. Give the path absolutely,
+and read `git show --stat` before believing a commit contains what you staged. `git worktree
+list` is the check; `git worktree remove <path>` is the repair, before amending.
+
 ## Whole-tree diff (mandatory whenever you change a gate)
 
 **The single most effective check in this repo.** Point the gate at the real corpus and compare

--- a/.claude/skills/metdsl-enforcement-change/references/verification.md
+++ b/.claude/skills/metdsl-enforcement-change/references/verification.md
@@ -49,9 +49,12 @@ python3 -m pytest tools/tests/ -q -p no:randomly
   version of this line claimed one permanent calibration skip and sent a reader hunting a test that
   does not exist
 
-## Two ways a verification step silently does not run
+## Verification steps that silently do not run, and records that silently do not hold
 
-Both were hit on issue #71, and both look exactly like a passing step.
+All of these were hit on issue #71, and each looks exactly like a passing step or a kept
+record. (An earlier version of this heading said "two ways" over five items — a hand-typed
+count, rotting inside the commit that wrote it, in the file that tells you not to hand-type
+counts.)
 
 **`cmd | tail && git commit` does not gate on `cmd`.** A pipeline exits with the status of its
 LAST element, so `python3 -m pytest … | tail -3 && git commit` commits whatever pytest did — the

--- a/.claude/skills/metdsl-enforcement-change/references/verification.md
+++ b/.claude/skills/metdsl-enforcement-change/references/verification.md
@@ -60,12 +60,36 @@ commit on top of a red suite. Either run the command bare and read the code (`py
 -q; echo $?`), or put the guard on the command itself and pipe afterwards
 (`set -o pipefail` also fixes it, but only if the shell honours it — check rather than assume).
 
-**`git worktree add -C <repo> <name>` resolves `<name>` against the repository, not your cwd.**
-`-C` changes directory before running, so a relative path meant for a scratch directory creates
-the worktree INSIDE the checkout, and the next `git add -A` commits it as a gitlink — git warns,
-in a hint block that is easy to scroll past, and the commit succeeds. Give the path absolutely,
-and read `git show --stat` before believing a commit contains what you staged. `git worktree
-list` is the check; `git worktree remove <path>` is the repair, before amending.
+**`git -C <repo> worktree add <name>` resolves `<name>` against `<repo>`, not your cwd.** `-C`
+is a global option and changes directory before the subcommand runs — written after the
+subcommand it is not even accepted (`error: unknown switch 'C'`, measured; an earlier version of
+this entry had it in that unusable position, in the file that says to execute what you write).
+So a relative path meant for a scratch directory creates the worktree INSIDE the checkout, and
+the next `git add -A` commits it as a gitlink; git warns, in a hint block that is easy to scroll
+past, and the commit succeeds. **The general rule is the one to keep: read `git show --stat`
+before believing a commit contains what you staged.** Give worktree paths absolutely; `git
+worktree list` is the check and `git worktree remove <path>` the repair, before amending.
+
+**A multi-edit script that asserts before writing loses the whole batch, silently.** Three times
+on issue #71 an edit reported as landed had not: a Python heredoc making several substitutions
+raised on a stale `assert` for one of them, after the earlier substitutions had been computed
+and before anything was written. The shell shows a traceback, the commit that follows says the
+work is done, and `git log -S` cannot find it. **One edit per script**, each asserting its own
+match count. This is the same failure as a commit message claiming work the artifact does not
+carry, arriving by a different road.
+
+**Name the mutation survivors in the commit message, individually.** "34 mutants, 30 killed, the
+four survivors confirmed equivalent or unreachable" is not a record: a later round cannot check
+it, cannot tell which four, and cannot tell equivalent from unreachable. On issue #71 that claim
+had to be replaced by re-running the sweep, because nothing could recover the list. A survivor
+you accept is a classification, and rule 1-b applies to it.
+
+**An instrument you commit needs a machine-readable verdict and its own test.** `measure_claude_tool.py`
+shipped with `main` returning 0 unconditionally, rows a reader classified by eye, and no test —
+and a review round then found five defects in it, two functional. If a script's output is
+evidence for a decision, it must be able to say PASS or FAIL, and an error (a timeout, a launch
+that produced nothing) must fail whatever the row expected rather than being scored as one of
+the two answers.
 
 ## Whole-tree diff (mandatory whenever you change a gate)
 

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -687,6 +687,34 @@ boundary was these two holding together:
 When both hold, the remainder has fallen to "an enumerable, finite set of descriptive fixes". One
 alone is not enough.
 
+**"Only prose remains" is a claim about SEVERITY, and it is wrong whenever the prose is executed
+by someone.** Issue #71 is the counterexample: functional defects stopped at round 11 and the
+last four rounds found none, both proxies above held — and rounds 12 through 15 each still found
+statements that were false, including a refusal message a leaf follows and a remedy an operator
+follows. Two of round 15's "prose" findings had real consequence: one made a leaf report absence
+after obeying half a remedy, the other told an operator to permanently subtract a tool from a
+required set to paper over a one-line configuration bug.
+
+So before calling the remainder descriptive, **classify each remaining finding by audience and
+consequence, not by whether it is code**:
+
+- **Text a leaf or an operator ACTS ON is behaviour delivered as prose** — refusal messages,
+  remedies, the leaf-read contract, the runbook step for a failure mode. Treat a defect there
+  at the severity of the action it causes
+- **Text a maintainer reads to decide** — a residue entry, a justification comment, a measured
+  number — is descriptive, and belongs in the bounded remainder
+- The tell that you are in the first category: the sentence contains an imperative, or names a
+  condition under which something is refused
+
+**The move that finds them: spend one round on the disclosure axis alone**, with no functional
+brief — "verify every claim in the commit messages at HEAD" and "read it as the next
+maintainer: what would mislead you, can the deletion's measurement be re-taken from what is
+written, what does a LEAF see, what does an OPERATOR see, would you merge". On issue #71 that
+round returned two real-consequence items and five documents stating the rule's own trigger
+wrongly, in a branch whose code had been clean for four rounds. **Run it before stopping, not
+as an extra round after deciding to stop** — and if it returns items in the first category
+above, the record has not converged even though the code has.
+
 **But the two are not equal in standing. Use them by change type.**
 
 - **changes that fix existing machinery** (closing a fail-open, tightening a gate): both apply. The

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -317,6 +317,11 @@ Test-file hunks are excluded by default (`--include-tests`
 **One round = two subagents in parallel**, on separate axes (security-bypass /
 correctness+regression+doc-truth).
 
+**But doc-truth bundled with correctness loses to it, measured** — so plan one round of the
+loop where BOTH agents are on disclosure alone, and plan it before you decide to stop rather
+than after. The evidence and the two briefs are under "Stopping conditions"; this line is here
+because a reader composing round prompts reaches that section 400 lines too late.
+
 - **Do not edit until both results are in.** Touch a file while one is running and its findings
   go stale (this happened). But in PR #53 one ran for **78 minutes** and I broke this rule twice.
   **Do not rely on the prohibition; absorb it in the launch prompt**:
@@ -688,12 +693,23 @@ When both hold, the remainder has fallen to "an enumerable, finite set of descri
 alone is not enough.
 
 **"Only prose remains" is a claim about SEVERITY, and it is wrong whenever the prose is executed
-by someone.** Issue #71 is the counterexample: functional defects stopped at round 11 and the
-last four rounds found none, both proxies above held — and rounds 12 through 15 each still found
-statements that were false, including a refusal message a leaf follows and a remedy an operator
-follows. Two of round 15's "prose" findings had real consequence: one made a leaf report absence
-after obeying half a remedy, the other told an operator to permanently subtract a tool from a
-required set to paper over a one-line configuration bug.
+by someone.** Issue #71 is the counterexample: both proxies above held from round 11, and rounds
+12 through 15 each still carried statements that were false, including a refusal message a leaf
+follows and a remedy an operator follows. Two of round 15's "prose" findings had real
+consequence: one made a leaf report absence after obeying half a remedy, the other told an
+operator to permanently subtract a tool from a required set to paper over a one-line
+configuration bug.
+
+**Be careful what you conclude from "the code was clean".** On that branch it was not quite
+true, and the way it was untrue is the more useful lesson: round 15 found five defects in a
+measurement SCRIPT the branch had committed — an environment built as a denylist, so one
+variable would have sent an unbilled probe to a real endpoint, and a timed-out launch scored as
+a successful read, so a run where nothing launched would have reported its premise holding.
+Those are functional defects. They went unfound for two rounds because **the reviewers were
+told to look at the enforcement code, and a committed instrument is not obviously that**. When
+a branch adds a script, a harness or a fixture generator to the repository, name it as review
+surface explicitly; "zero functional defects" otherwise means "zero in the files anyone
+looked at".
 
 So before calling the remainder descriptive, **classify each remaining finding by audience and
 consequence, not by whether it is code**:
@@ -707,7 +723,10 @@ consequence, not by whether it is code**:
   condition under which something is refused
 
 **The move that finds them: spend one round on the disclosure axis alone**, with no functional
-brief — "verify every claim in the commit messages at HEAD" and "read it as the next
+brief. Note what this implies about the standing arrangement: doc-truth is already bundled into
+the correctness axis of every round (see "Running a round"), and on issue #71 that bundling did
+NOT fire for four rounds while five documents stated a rule's own trigger wrongly. Bundled, it
+loses to whatever functional question shares the brief. Give it a round of its own — "verify every claim in the commit messages at HEAD" and "read it as the next
 maintainer: what would mislead you, can the deletion's measurement be re-taken from what is
 written, what does a LEAF see, what does an OPERATOR see, would you merge". On issue #71 that
 round returned two real-consequence items and five documents stating the rule's own trigger
@@ -813,7 +832,10 @@ as a disclosure** (PR #53: 5 fail-opens and 1 false positive came from my own fi
   **your own fixes** — put the focus instruction in from the first round
 - **You have rewritten the same string three times** → the problem is not the rule but the prose
   citing it. Switch to the grep sweep
-  (`.claude/skills/metdsl-enforcement-change/references/verification.md`)
+  (`.claude/skills/metdsl-enforcement-change/references/verification.md`). **Three rewrites of
+  ONE statement is a sweep problem; three SITES that each state the rule is a coupling problem**
+  — for the second, `metdsl-enforcement-change` rule 3-a, which is canonical for both thresholds
+  so they cannot drift apart again
 - **Prose that enumerates entities in the code** (lists of test names, counts of call sites,
   numbers of readers) → **re-measuring loses. Turn it into a check.** Unlike a number measured once,
   this kind of prose **rots silently on every rename or addition**. PR #57's breakdown of test
@@ -821,7 +843,9 @@ as a disclosure** (PR #53: 5 fail-opens and 1 false positive came from my own fi
   three times — "all 7 iterate" (5) → a test name that a rename had removed → "8" (9). The fourth
   fix **stopped fixing the number** and put `_DEFINITION_DRIVEN` / `_SAMPLE_DRIVEN` in data with one
   test cross-checking them against the class's real methods (confirmed to fail on rename).
-  **Criterion: should this prose break if one test is renamed? Then make it a check**
+  **Criterion: should this prose break if one test is renamed? Then make it a check** (the
+  general form of this, and when a check is the wrong answer, is rule 3-a — this row is the
+  enumeration case of it)
 - **A fix changed the shape of the rule** (denylist → allowlist and the like) → split everything
   after that into another PR. Stacking 25 commits on one branch compounds fixes calling for fixes.
   If you continue without splitting, **give the user the options and ask** (L128 redesigned in

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -317,10 +317,11 @@ Test-file hunks are excluded by default (`--include-tests`
 **One round = two subagents in parallel**, on separate axes (security-bypass /
 correctness+regression+doc-truth).
 
-**But doc-truth bundled with correctness loses to it, measured** — so plan one round of the
-loop where BOTH agents are on disclosure alone, and plan it before you decide to stop rather
-than after. The evidence and the two briefs are under "Stopping conditions"; this line is here
-because a reader composing round prompts reaches that section 400 lines too late.
+**One round of the loop puts BOTH agents on the disclosure axis instead** — doc-truth bundled
+with correctness loses to it, measured. Plan it before you decide to stop. The evidence and the
+two briefs are under "Stopping conditions"; this line is here because a reader composing round
+prompts reaches that section 400 lines later. **A disclosure round runs no security agent, so
+it neither advances nor resets the two-consecutive-clean-security-rounds condition below.**
 
 - **Do not edit until both results are in.** Touch a file while one is running and its findings
   go stale (this happened). But in PR #53 one ran for **78 minutes** and I broke this rule twice.
@@ -668,8 +669,9 @@ out of scope", stop at that round.** More rounds produce the same layer, and fix
 diff away from the purpose. State the out-of-scope breakdown and why you declared the scope.
 
 **The superior condition (stop there if you reach it)**: the security axis produces **nothing new
-for two consecutive rounds**. It has **never been achieved in any recorded loop** — the
-nine histories in `references/class-descent-log.md`, plus PR #51. **Run assuming you will not reach
+for two consecutive rounds** (a disclosure round, which runs no security agent, is skipped in
+that count rather than breaking it). It has **never been achieved in any recorded loop** — the
+histories in `references/class-descent-log.md`, plus PR #51. **Run assuming you will not reach
 it** — do not add rounds waiting for it.
 
 **Do not make "Codex is clean" a stopping condition.** As a condition it becomes **a motive to
@@ -693,7 +695,8 @@ When both hold, the remainder has fallen to "an enumerable, finite set of descri
 alone is not enough.
 
 **"Only prose remains" is a claim about SEVERITY, and it is wrong whenever the prose is executed
-by someone.** Issue #71 is the counterexample: both proxies above held from round 11, and rounds
+by someone.** Issue #71 is the counterexample: both proxies above read as held from round 11 — the second
+of them wrongly, see below — and rounds
 12 through 15 each still carried statements that were false, including a refusal message a leaf
 follows and a remedy an operator follows. Two of round 15's "prose" findings had real
 consequence: one made a leaf report absence after obeying half a remedy, the other told an
@@ -724,15 +727,15 @@ consequence, not by whether it is code**:
 
 **The move that finds them: spend one round on the disclosure axis alone**, with no functional
 brief. Note what this implies about the standing arrangement: doc-truth is already bundled into
-the correctness axis of every round (see "Running a round"), and on issue #71 that bundling did
-NOT fire for four rounds while five documents stated a rule's own trigger wrongly. Bundled, it
-loses to whatever functional question shares the brief. Give it a round of its own — "verify every claim in the commit messages at HEAD" and "read it as the next
-maintainer: what would mislead you, can the deletion's measurement be re-taken from what is
-written, what does a LEAF see, what does an OPERATOR see, would you merge". On issue #71 that
-round returned two real-consequence items and five documents stating the rule's own trigger
-wrongly, in a branch whose code had been clean for four rounds. **Run it before stopping, not
-as an extra round after deciding to stop** — and if it returns items in the first category
-above, the record has not converged even though the code has.
+the correctness axis of every round (see "Running a round"), and bundled it loses to whatever
+functional question shares the brief. Give it a round of its own, with two briefs: "verify
+every claim in the commit messages at HEAD" and "read it as the next maintainer: what would
+mislead you, can the deletion's measurement be re-taken from what is written, what does a LEAF
+see, what does an OPERATOR see, would you merge". On issue #71 that round returned two
+real-consequence items and five documents stating the rule's own trigger wrongly — one of them
+a document every leaf reads — in a branch whose ENFORCEMENT CODE had been clean for four
+rounds. **Run it before stopping, not as an extra round after deciding to stop** — and if it returns items in the first category
+above, the record has not converged even though the enforcement code has.
 
 **But the two are not equal in standing. Use them by change type.**
 
@@ -832,10 +835,10 @@ as a disclosure** (PR #53: 5 fail-opens and 1 false positive came from my own fi
   **your own fixes** — put the focus instruction in from the first round
 - **You have rewritten the same string three times** → the problem is not the rule but the prose
   citing it. Switch to the grep sweep
-  (`.claude/skills/metdsl-enforcement-change/references/verification.md`). **Three rewrites of
-  ONE statement is a sweep problem; three SITES that each state the rule is a coupling problem**
-  — for the second, `metdsl-enforcement-change` rule 3-a, which is canonical for both thresholds
-  so they cannot drift apart again
+  (`.claude/skills/metdsl-enforcement-change/references/verification.md`). **Rewriting one statement
+  repeatedly is a SWEEP problem, which this row owns; several sites that each state the rule is a
+  COUPLING problem, which `metdsl-enforcement-change` rule 3-a owns and states the threshold
+  for.** Do not restate its number here — that is the drift this pair is about
 - **Prose that enumerates entities in the code** (lists of test names, counts of call sites,
   numbers of readers) → **re-measuring loses. Turn it into a check.** Unlike a number measured once,
   this kind of prose **rots silently on every rename or addition**. PR #57's breakdown of test

--- a/.claude/skills/metdsl-review-loop/references/class-descent-log.md
+++ b/.claude/skills/metdsl-review-loop/references/class-descent-log.md
@@ -9,25 +9,26 @@ to the content filter — `codex-episodes.md` has them); PR #53 ran 3 rounds
 with none empty and Codex never clean (it found a hole on the first pass); in PR #55 round 3 both
 a subagent and Codex produced new findings.
 
-## issue #71 — the proxies held from R11 and four more rounds still found real defects
+## issue #71 — the proxies read as held from R11 and four more rounds found real defects
 
 15 rounds, the longest recorded. R1-R5 "witnesses weaker than their names, and four of my own
-'measurements' of a vendor tool were measurements of something else" → R8 "a brace alternation
-walked out of the manifest, found by a reviewer" → R11 **"the rounds are reliable about code and
-unreliable about their own record"** → R12 narrowing (a net 164 lines out of `tools/hooks/cli.py`)
-→ R13-R15 "no defect in the enforcement code, and a false or missing statement every round".
+'measurements' of a vendor tool were measurements of something else — Python's `glob` twice and
+bare `ripgrep` once, each written down as the tool" → R8 "a brace alternation walked out of the
+manifest, found by a reviewer" → R11 **"the rounds are reliable about code and unreliable about
+their own record"** → R12 narrowing (a net 164 lines out of `tools/hooks/cli.py`) → R13-R15 "no
+defect in the enforcement code, and a false or missing statement every round".
 
-What ends the loop is not what this history teaches. Two things it is the evidence for, both now
-in SKILL.md's stopping conditions: **"only prose remains" is a claim about severity** that fails
-when a leaf or an operator acts on the prose, and **a round spent on disclosure alone is worth
-running before stopping** — that round found five documents stating a rule's own trigger wrongly,
-one of them a document every leaf reads.
+Evidence for two of SKILL.md's stopping conditions — that "only prose remains" is a claim about
+severity, and that a disclosure round is worth running before stopping. **And for the limit of
+proxy 1**: R15 found five defects in a measurement script the branch had COMMITTED, one of them
+functional (a denylist environment that could send an unbilled probe to a real endpoint). Nobody
+had been asked to review it, because the briefs named the enforcement code — so "a reviewer with
+no exclusions returns zero functional defects" was true of the files anyone looked at. A
+committed instrument is review surface.
 
-**And "the code was clean" was itself imprecise**, which is the sharper lesson: R15 found five
-defects in a measurement script the branch had COMMITTED, two of them functional (a denylist
-environment that could send an unbilled probe to a real endpoint; a timed-out launch scored as a
-successful read). Nobody had been asked to review it, because the briefs named the enforcement
-code. A committed instrument is review surface.
+Defects introduced by the fixes themselves recurred in most rounds — four in the final round
+alone, of which the one recorded nowhere else is a correction to the leaf-read contract that
+blew its byte ceiling: the fix was right and its LENGTH was the defect.
 
 ## issue #63 — the first time both proxies held at once (R4)
 

--- a/.claude/skills/metdsl-review-loop/references/class-descent-log.md
+++ b/.claude/skills/metdsl-review-loop/references/class-descent-log.md
@@ -9,6 +9,38 @@ to the content filter — `codex-episodes.md` has them); PR #53 ran 3 rounds
 with none empty and Codex never clean (it found a hole on the first pass); in PR #55 round 3 both
 a subagent and Codex produced new findings.
 
+## issue #71 — both proxies held for four rounds while the record stayed wrong
+
+The longest recorded loop: **15 rounds**, and the only one where the two stopping proxies held
+early and stayed held while real defects kept arriving.
+
+R1-R2 "witnesses weaker than their names; my own R1 fix was cosmetic and its justification
+false" → R3-R5 "an escape I 'fixed' twice cannot happen — and my four 'measurements' of the tool
+were Python's `glob` twice and bare `ripgrep` once" → R8 "a brace alternation walked out of the
+manifest, found by a reviewer" → R9 "I drove the real tool at last" → R11 **"the rounds were
+reliable about code and unreliable about their own record"** → R12 narrowing (a NET 164 lines out of `tools/hooks/cli.py`: +47 -211)
+→ **R13, R14, R15: zero functional defects, and false or missing statements every round.**
+
+What R15 found, in a branch whose code had been clean for four rounds: **five canonical documents
+stating the rule's own trigger wrongly**, one of them the only document a leaf reads; a refusal a
+leaf could follow by half and get a silent empty result; an operator remedy whose first move
+widened the check; a TODO residue falsified by its own commit's artifact; a "production caller"
+no callable answers to; and a committed re-check that could not see the reopening it warns about.
+
+**Two things this history is the evidence for**, both now in SKILL.md: that "only prose remains"
+is a claim about severity which fails when the prose is executed by a leaf or an operator, and
+that a round spent on the disclosure axis alone is worth running before stopping. A third is in
+`metdsl-enforcement-change` rule 3-a: **discipline about sweeping the prose failed four
+consecutive rounds after being diagnosed**, and what ended it was a test reading the rule's
+constant out of the code and requiring every statement site to name every member.
+
+**Defects introduced by the fixes themselves recurred in most rounds** — four in the final
+round alone, each named in its own commit: a contract sentence that blew the leaf-read byte
+ceiling, a harness scoring a TIMEOUT as a read (so a run where every launch failed would have
+reported the premise holding), an anchor taken from my own corrected wording (pinning that the
+correction survived rather than that the rule is stated), and a `git worktree` created inside
+the checkout and committed as a gitlink.
+
 ## issue #63 — the first time both proxies held at once (R4)
 
 R1 "mechanism holes in the original design (credential exposure / cross-leaf transcript reads) plus

--- a/.claude/skills/metdsl-review-loop/references/class-descent-log.md
+++ b/.claude/skills/metdsl-review-loop/references/class-descent-log.md
@@ -9,37 +9,25 @@ to the content filter — `codex-episodes.md` has them); PR #53 ran 3 rounds
 with none empty and Codex never clean (it found a hole on the first pass); in PR #55 round 3 both
 a subagent and Codex produced new findings.
 
-## issue #71 — both proxies held for four rounds while the record stayed wrong
+## issue #71 — the proxies held from R11 and four more rounds still found real defects
 
-The longest recorded loop: **15 rounds**, and the only one where the two stopping proxies held
-early and stayed held while real defects kept arriving.
+15 rounds, the longest recorded. R1-R5 "witnesses weaker than their names, and four of my own
+'measurements' of a vendor tool were measurements of something else" → R8 "a brace alternation
+walked out of the manifest, found by a reviewer" → R11 **"the rounds are reliable about code and
+unreliable about their own record"** → R12 narrowing (a net 164 lines out of `tools/hooks/cli.py`)
+→ R13-R15 "no defect in the enforcement code, and a false or missing statement every round".
 
-R1-R2 "witnesses weaker than their names; my own R1 fix was cosmetic and its justification
-false" → R3-R5 "an escape I 'fixed' twice cannot happen — and my four 'measurements' of the tool
-were Python's `glob` twice and bare `ripgrep` once" → R8 "a brace alternation walked out of the
-manifest, found by a reviewer" → R9 "I drove the real tool at last" → R11 **"the rounds were
-reliable about code and unreliable about their own record"** → R12 narrowing (a NET 164 lines out of `tools/hooks/cli.py`: +47 -211)
-→ **R13, R14, R15: zero functional defects, and false or missing statements every round.**
+What ends the loop is not what this history teaches. Two things it is the evidence for, both now
+in SKILL.md's stopping conditions: **"only prose remains" is a claim about severity** that fails
+when a leaf or an operator acts on the prose, and **a round spent on disclosure alone is worth
+running before stopping** — that round found five documents stating a rule's own trigger wrongly,
+one of them a document every leaf reads.
 
-What R15 found, in a branch whose code had been clean for four rounds: **five canonical documents
-stating the rule's own trigger wrongly**, one of them the only document a leaf reads; a refusal a
-leaf could follow by half and get a silent empty result; an operator remedy whose first move
-widened the check; a TODO residue falsified by its own commit's artifact; a "production caller"
-no callable answers to; and a committed re-check that could not see the reopening it warns about.
-
-**Two things this history is the evidence for**, both now in SKILL.md: that "only prose remains"
-is a claim about severity which fails when the prose is executed by a leaf or an operator, and
-that a round spent on the disclosure axis alone is worth running before stopping. A third is in
-`metdsl-enforcement-change` rule 3-a: **discipline about sweeping the prose failed four
-consecutive rounds after being diagnosed**, and what ended it was a test reading the rule's
-constant out of the code and requiring every statement site to name every member.
-
-**Defects introduced by the fixes themselves recurred in most rounds** — four in the final
-round alone, each named in its own commit: a contract sentence that blew the leaf-read byte
-ceiling, a harness scoring a TIMEOUT as a read (so a run where every launch failed would have
-reported the premise holding), an anchor taken from my own corrected wording (pinning that the
-correction survived rather than that the rule is stated), and a `git worktree` created inside
-the checkout and committed as a gitlink.
+**And "the code was clean" was itself imprecise**, which is the sharper lesson: R15 found five
+defects in a measurement script the branch had COMMITTED, two of them functional (a denylist
+environment that could send an unbilled probe to a real endpoint; a timed-out launch scored as a
+successful read). Nobody had been asked to review it, because the briefs named the enforcement
+code. A committed instrument is review surface.
 
 ## issue #63 — the first time both proxies held at once (R4)
 

--- a/tools/tests/test_hooks_cli.py
+++ b/tools/tests/test_hooks_cli.py
@@ -4424,10 +4424,29 @@ class GlobPatternTriggerSurfaceTests(unittest.TestCase):
 
     @classmethod
     def _trigger_prefixes(cls) -> tuple[str, ...]:
-        """The literal prefixes the hook refuses on, read out of the hook's source."""
+        """The literal prefixes the hook refuses on, read out of the hook's source.
+
+        A NAMED CONSTANT is resolved rather than refused. The first version matched only
+        `pattern.startswith((...))` with the tuple inline, so extracting it to
+        `_PREFIXES = ("/", "~")` — a refactor that changes nothing — raised its assertion
+        and turned a set of true documents red, with a message naming no repair. That is
+        an over-refusal on correct work, and this class is the exemplar
+        `metdsl-enforcement-change` rule 3-a tells a reader to copy, so the flaw would have
+        been copied with it.
+        """
         source = (cls._REPO_ROOT / "tools" / "hooks" / "cli.py").read_text(encoding="utf-8")
-        match = re.search(r"pattern\.startswith\(\(([^)]*)\)\)", source)
-        assert match is not None, "the pattern trigger is no longer a startswith tuple"
+        match = re.search(r"pattern\.startswith\(\s*\(([^)]*)\)\s*\)", source)
+        if match is None:
+            named = re.search(r"pattern\.startswith\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)", source)
+            assert named is not None, (
+                "the pattern trigger is neither an inline tuple nor a named constant; "
+                "point this reader at wherever the prefixes now live")
+            definition = re.search(
+                rf"^{named.group(1)}\s*(?::[^=]+)?=\s*\(([^)]*)\)", source, re.M)
+            assert definition is not None, (
+                f"the trigger names {named.group(1)}, which is not defined as a literal "
+                "tuple in this module; read it from wherever it is defined")
+            match = definition
         return tuple(re.findall(r'"([^"]*)"', match.group(1)))
 
     @classmethod

--- a/tools/tests/test_skill_citations.py
+++ b/tools/tests/test_skill_citations.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""The dev skills under `.claude/skills/` cite this repository; the citations must resolve.
+
+These files are DEV-ONLY — no workflow leaf reads them (`CLAUDE.md` is canonical for that) —
+but they are what an operator and every review subagent are handed, and they are dense with
+pointers into the tree: file paths, `path::symbol` references, and quotations of code. Nothing
+measured them. `.claude/skills/**` matches none of the backend-boundary scanner's globs, and
+the suite reached into that directory only for the one script it owns.
+
+Two checks, both narrow on purpose. **A check that parses prose to decide what a claim IS will
+refuse correct writing** — that failure took two rebuilds and a scope declaration on the
+TODO:414 branch — so nothing here reads a sentence. The first check keys on the SHAPE of a
+token (a backticked string starting with a repository directory), the second on a spelling the
+code owns.
+
+The second is this repository's own rule applied to the file that states it:
+`metdsl-enforcement-change` rule 3-a says that past three statement sites, a rule's documents
+must be COUPLED to the rule by reading its constant out of the code. That rule is stated in a
+document which quotes the constant. So it is coupled here.
+"""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS = REPO_ROOT / ".claude" / "skills"
+
+# A backticked token is treated as a repository citation when it starts with one of these and
+# carries no glob metacharacter or space. That excludes the illustrative paths these documents
+# are full of — `~/.bashrc`, `/etc/hostname`, `docs/**/*.md`, `<repo>/spec/*` — without
+# reading what any sentence is claiming.
+_CITATION_PREFIXES = ("docs/", "tools/", "mcp_servers/", "skills/", ".claude/", "spec/")
+_NOT_A_CITATION = "*?<>| "
+
+
+def repository_citations(text: str) -> list[str]:
+    """Every backticked token in `text` that names a path in this repository."""
+    found = []
+    for token in sorted(set(re.findall(r"`([^`\n]+)`", text))):
+        if not token.startswith(_CITATION_PREFIXES):
+            continue
+        if any(char in token for char in _NOT_A_CITATION):
+            continue
+        found.append(token.rstrip(".,;:)"))
+    return found
+
+
+def unresolved(token: str, root: Path) -> str:
+    """"" if the citation resolves, else why it does not."""
+    path, _, symbol = token.partition("::")
+    target = root / path
+    if not target.exists():
+        return "file does not exist"
+    if symbol and symbol.split("::")[0] not in target.read_text(encoding="utf-8"):
+        return "file exists but does not contain the symbol"
+    return ""
+
+
+class SkillCitationTests(unittest.TestCase):
+
+    def test_every_repository_path_a_skill_cites_resolves(self) -> None:
+        """A pointer nobody can follow is worse than no pointer.
+
+        These documents are read by subagents that cannot ask a question. On the issue #71
+        branch, three places asserted that `TODO.md` carried a measurement harness while it
+        carried a pointer to a file that had never been in this repository, and four sites
+        named a production caller no callable answers to.
+        """
+        broken = []
+        for path in sorted(SKILLS.rglob("*.md")):
+            text = path.read_text(encoding="utf-8")
+            for token in repository_citations(text):
+                why = unresolved(token, REPO_ROOT)
+                if why:
+                    broken.append(f"{path.relative_to(REPO_ROOT)}: `{token}` — {why}")
+        self.assertEqual(broken, [], "\n".join(broken))
+
+    def test_the_glob_trigger_quoted_by_the_skill_is_the_one_the_hook_uses(self) -> None:
+        """Rule 3-a, applied to the document that states it.
+
+        The rule says: past three statement sites, read the rule's constant out of the code
+        and require every statement to name it. `SKILL.md` quotes the `Glob` pattern trigger
+        as the worked example. If the hook's trigger changes, that example becomes one more
+        document stating a rule wrongly — which is the exact failure the rule exists to stop,
+        occurring inside its own explanation.
+        """
+        hook = (REPO_ROOT / "tools" / "hooks" / "cli.py").read_text(encoding="utf-8")
+        match = re.search(r"pattern\.startswith\(\(([^)]*)\)\)", hook)
+        self.assertIsNotNone(match, "the pattern trigger is no longer a startswith tuple")
+        assert match is not None
+        spelling = f"pattern.startswith(({match.group(1)}))"
+        skill = (SKILLS / "metdsl-enforcement-change" / "SKILL.md").read_text(encoding="utf-8")
+        # `assertTrue`, not `assertIn`: the failure message of `assertIn` prints the whole
+        # haystack, and the haystack here is a 700-line document. A check whose failure has
+        # to be scrolled past is a check that gets weakened rather than answered.
+        self.assertTrue(
+            spelling in skill,
+            f"the skill quotes a trigger the hook no longer uses; the hook's is {spelling!r}")
+
+
+class CitationScannerSelfTests(unittest.TestCase):
+    """SELF-TEST. Both checks above assert an ABSENCE of findings, so a scanner that found
+    nothing at all would pass them for ever. The rule is defined once, above, and driven here
+    from both sides — one text that must produce a finding and one that must not."""
+
+    def test_a_broken_citation_is_found(self) -> None:
+        text = "see `tools/this_file_does_not_exist.py` for the procedure"
+        tokens = repository_citations(text)
+        self.assertEqual(tokens, ["tools/this_file_does_not_exist.py"])
+        self.assertTrue(unresolved(tokens[0], REPO_ROOT))
+
+    def test_a_missing_symbol_is_found(self) -> None:
+        self.assertTrue(
+            unresolved("tools/hooks/cli.py::_no_such_symbol_here", REPO_ROOT))
+        self.assertFalse(
+            unresolved("tools/hooks/cli.py::_evaluate_grep_glob_read_policy", REPO_ROOT))
+
+    def test_illustrative_paths_are_not_treated_as_citations(self) -> None:
+        """The over-refusal direction, which is the one that makes a check get deleted.
+
+        These documents teach by quoting patterns and host paths. Reading `~/.bashrc` or
+        `docs/**/*.md` as a citation would fail the suite for correct writing, and the fix
+        would be to weaken the check rather than the prose.
+        """
+        text = ("`~/.bashrc` and `/etc/hostname` read, while `docs/**/*.md`, `<repo>/spec/*` "
+                "and `tools/hooks/cli.py` are different shapes")
+        self.assertEqual(repository_citations(text), ["tools/hooks/cli.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_skill_citations.py
+++ b/tools/tests/test_skill_citations.py
@@ -21,15 +21,19 @@ Two properties the first draft lacked, both found by review:
 - **The corpus is discovered from git and its size is asserted.** Moving `references/` out from
   under a skill made the scan find nothing and pass — an empty corpus satisfies an
   absence-assertion for ever.
-- **Nothing touches the filesystem.** The first draft asked `Path.exists()`, so a gitignored
-  file present in the author's checkout passed here and failed in every clone; the repair
-  after that still `read_text()` its way to a `FileNotFoundError` on a tree whose index and
-  worktree disagree. Git is asked once, and it is the only thing asked.
+- **Nothing touches the filesystem** — neither the path set nor the CONTENT. The first draft
+  asked `Path.exists()`, so a gitignored file present in the author's checkout passed here and
+  failed in every clone. The first repair fixed only the path set and still `read_text()` its
+  way to a `FileNotFoundError` on a tree whose index and worktree disagree; it said in its own
+  docstring that it had fixed both, which is the class this branch exists to stop. Paths come
+  from `git ls-files` and bodies from `git show :<path>`, so both sides read the same index.
 """
 from __future__ import annotations
 
+import functools
 import re
 import subprocess
+import tempfile
 import unittest
 from functools import lru_cache
 from pathlib import Path
@@ -79,7 +83,12 @@ def normalize(token: str) -> str:
     """
     token = token.rstrip(".,;:)").rstrip("/")
     token = token.split("#", 1)[0].split("::", 1)[0]
-    return re.sub(r":\d+$", "", token)
+    # A locator is a line, a line RANGE, or either with an `L` prefix; a possessive `'s` is
+    # ordinary prose around a filename. The first version handled only a bare single line, so
+    # `cli.py:120-140`, `HOOKS.md:L14` and `cli.py's` were all refused — over-refusal on
+    # correct writing, which is what gets a check weakened instead of answered.
+    token = re.sub(r"'s$", "", token)
+    return re.sub(r":L?\d+(-L?\d+)?$", "", token)
 
 
 def citation_targets(text: str, source: str) -> list[str]:
@@ -121,7 +130,39 @@ def skill_documents() -> tuple[str, ...]:
                         if f.startswith(SKILL_ROOT + "/") and f.endswith(".md")))
 
 
+def document_body(path: str, root: Path = REPO_ROOT) -> str:
+    """The document as the INDEX holds it.
+
+    Not `read_text`. A tree whose index and worktree disagree — a deletion not yet staged, a
+    partial or sparse checkout, a rebase in flight — makes the filesystem read raise while the
+    path set says the file is there, so the check dies with `FileNotFoundError` instead of
+    reporting on citations. The two halves have to ask the same source.
+    """
+    return subprocess.run(["git", "show", f":{path}"], cwd=root,
+                          capture_output=True, text=True, check=True).stdout
+
+
+def skill_names() -> frozenset[str]:
+    """The skill directories git tracks a document in."""
+    return frozenset(document.split("/")[2] for document in skill_documents())
+
+
 class SkillCitationTests(unittest.TestCase):
+
+    @staticmethod
+    def _corpus_by_pathspec() -> frozenset[str]:
+        """The corpus again, asked of git a DIFFERENT way.
+
+        `skill_documents()` filters the full `ls-files` output in Python; this asks git to do
+        the matching with a glob pathspec. Two derivations, so a change to either one's filter
+        shows up as a disagreement — a floor expressed as a count did not: dropping every
+        `references/` document (a third of the corpus, including the file this branch edited)
+        still cleared "at least 6 documents, at least 30 citations".
+        """
+        out = subprocess.run(
+            ["git", "ls-files", "-z", "--", f":(glob){SKILL_ROOT}/**/*.md"],
+            cwd=REPO_ROOT, capture_output=True, text=True, check=True).stdout
+        return frozenset(entry for entry in out.split("\0") if entry)
 
     def test_every_repository_path_a_skill_cites_is_tracked(self) -> None:
         """A pointer nobody can follow is worse than no pointer.
@@ -132,7 +173,7 @@ class SkillCitationTests(unittest.TestCase):
         """
         broken = []
         for document in skill_documents():
-            text = (REPO_ROOT / document).read_text(encoding="utf-8")
+            text = document_body(document)
             for target in citation_targets(text, document):
                 if not is_tracked(target):
                     broken.append(f"{document}: `{target}` is not a tracked path")
@@ -147,10 +188,15 @@ class SkillCitationTests(unittest.TestCase):
         rather than an equality because these documents are edited constantly.
         """
         documents = skill_documents()
-        self.assertGreaterEqual(len(documents), 6, documents)
-        total = sum(len(citation_targets((REPO_ROOT / d).read_text(encoding="utf-8"), d))
-                    for d in documents)
-        self.assertGreaterEqual(total, 30, f"only {total} citations found — is the scan live?")
+        # STRUCTURAL, not just a number. A floor of "6 documents / 30 citations" was measured
+        # to pass with a THIRD of the corpus dropped — including the reference file this branch
+        # edited — because the remainder still cleared it. What must hold is that every skill
+        # git tracks a document in is represented, and that each contributes something.
+        self.assertEqual(frozenset(documents), self._corpus_by_pathspec())
+        for name in sorted(skill_names()):
+            docs = [d for d in documents if d.split("/")[2] == name]
+            found = sum(len(citation_targets(document_body(d), d)) for d in docs)
+            self.assertGreater(found, 0, f"{name} contributed no citations — is the scan live?")
 
 
 class CitationScannerSelfTests(unittest.TestCase):
@@ -164,10 +210,18 @@ class CitationScannerSelfTests(unittest.TestCase):
         self.assertEqual(targets, ["tools/no_such_file.py"])
         self.assertFalse(is_tracked(targets[0]))
 
-    def test_a_path_untracked_but_present_locally_is_not_accepted(self) -> None:
-        """The environment-dependence a round-0 worktree run exposed: `workspace/` is
-        gitignored and populated in a working checkout, absent from a clone."""
-        self.assertFalse(is_tracked("workspace/orchestrations"))
+    def test_a_path_untracked_but_present_on_disk_is_not_accepted(self) -> None:
+        """The witness for "git, not the filesystem" — and it must hold in EVERY checkout.
+
+        The first version of this row named `workspace/orchestrations`, which is gitignored
+        and populated in a working checkout and ABSENT from a clone. So in a clone it passed
+        because the path did not exist, not because the predicate asks git: reverting
+        `is_tracked` to `Path.exists()` left all nine rows green there. The witness has to name
+        something that is present in every checkout and tracked in none. `.git` is exactly
+        that — a directory in a main checkout, a file in a linked worktree, never tracked.
+        """
+        self.assertTrue((REPO_ROOT / ".git").exists(), "no .git — this row cannot witness")
+        self.assertFalse(is_tracked(".git"))
         self.assertTrue(is_tracked("tools/hooks"))
 
     def test_a_deliberately_untracked_citation_is_exempt_by_name(self) -> None:
@@ -190,6 +244,30 @@ class CitationScannerSelfTests(unittest.TestCase):
             citation_targets("`scripts/measure_claude_tool.py`", source),
             [f"{SKILL_ROOT}/metdsl-enforcement-change/scripts/measure_claude_tool.py"])
 
+    def test_the_body_is_read_from_the_index_not_the_worktree(self) -> None:
+        """The property the previous round claimed to have fixed and had not.
+
+        Replacing `document_body` with `read_text` passes in any checkout where the index and
+        the worktree agree — which is every checkout the suite normally runs in, so the
+        mutation survived and the docstring's claim went unwitnessed. A tree where they
+        DISAGREE has to be built: this stages a file and then deletes it from disk, which is
+        an unstaged deletion, a partial checkout and a rebase in flight all at once as far as
+        this predicate is concerned.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run = functools.partial(subprocess.run, cwd=root, check=True,
+                                    capture_output=True, text=True)
+            run(["git", "init", "-q"])
+            run(["git", "config", "user.email", "t@example.invalid"])
+            run(["git", "config", "user.name", "t"])
+            (root / "doc.md").write_text("cites `tools/hooks/cli.py`", encoding="utf-8")
+            run(["git", "add", "doc.md"])
+            (root / "doc.md").unlink()
+            self.assertEqual(document_body("doc.md", root), "cites `tools/hooks/cli.py`")
+            with self.assertRaises(FileNotFoundError):
+                (root / "doc.md").read_text(encoding="utf-8")
+
     def test_prose_that_only_looks_like_a_path_is_not_a_citation(self) -> None:
         """The over-refusal direction, which is what gets a check deleted rather than fixed.
 
@@ -202,7 +280,8 @@ class CitationScannerSelfTests(unittest.TestCase):
 
     def test_an_anchor_or_a_line_number_does_not_break_a_citation(self) -> None:
         for spelling in ("docs/HOOKS.md#the-rule", "docs/HOOKS.md:14", "docs/HOOKS.md::absolute",
-                         "tools/tests/"):
+                         "tools/tests/", "tools/hooks/cli.py:120-140", "docs/HOOKS.md:L14",
+                         "docs/HOOKS.md#L14", "tools/hooks/cli.py's"):
             with self.subTest(spelling):
                 targets = citation_targets(f"`{spelling}`", self._SOURCE)
                 self.assertEqual(len(targets), 1, spelling)

--- a/tools/tests/test_skill_citations.py
+++ b/tools/tests/test_skill_citations.py
@@ -21,7 +21,9 @@ document which quotes the constant. So it is coupled here.
 from __future__ import annotations
 
 import re
+import subprocess
 import unittest
+from functools import lru_cache
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -43,18 +45,56 @@ def repository_citations(text: str) -> list[str]:
             continue
         if any(char in token for char in _NOT_A_CITATION):
             continue
-        found.append(token.rstrip(".,;:)"))
+        # A trailing slash marks a directory in prose (`tools/tests/`); git tracks the
+        # directory under its bare name, so both spellings must reach the same lookup.
+        found.append(token.rstrip(".,;:)").rstrip("/"))
     return found
+
+
+# Citations to paths this repository deliberately does NOT track. Each is named, with the
+# reason, rather than matched by a pattern: an untracked path is exactly what a stale pointer
+# looks like, so the exemption must be a decision and not a shape.
+_UNTRACKED_ON_PURPOSE = {
+    # The operator's machine-local settings layer. The skill names it to say what it is NOT
+    # (not read by a leaf, not consulted by the permission gate), which is why it is cited at
+    # all — and it cannot be tracked without becoming the thing it is contrasted with.
+    ".claude/settings.local.json",
+}
+
+
+@lru_cache(maxsize=1)
+def tracked_paths() -> frozenset[str]:
+    """Every path git tracks, plus every directory prefix of one.
+
+    Judged against GIT, not against the filesystem. The first version of this check asked
+    `Path.exists()` and passed in the author's checkout while failing in a fresh worktree,
+    because a gitignored machine-local file happened to be present — the "a test passes
+    because of its own environment" shape this repository has recorded twice. It was caught
+    by the round-0 mutation run, which builds worktrees, and not by the suite.
+    """
+    out = subprocess.run(["git", "ls-files", "-z"], cwd=REPO_ROOT,
+                         capture_output=True, text=True, check=True).stdout
+    paths = set()
+    for entry in out.split("\0"):
+        if not entry:
+            continue
+        paths.add(entry)
+        parts = entry.split("/")
+        for i in range(1, len(parts)):
+            paths.add("/".join(parts[:i]))
+    return frozenset(paths)
 
 
 def unresolved(token: str, root: Path) -> str:
     """"" if the citation resolves, else why it does not."""
     path, _, symbol = token.partition("::")
+    if path in _UNTRACKED_ON_PURPOSE:
+        return ""
+    if path not in tracked_paths():
+        return "not a tracked path"
     target = root / path
-    if not target.exists():
-        return "file does not exist"
     if symbol and symbol.split("::")[0] not in target.read_text(encoding="utf-8"):
-        return "file exists but does not contain the symbol"
+        return "file is tracked but does not contain the symbol"
     return ""
 
 
@@ -110,6 +150,19 @@ class CitationScannerSelfTests(unittest.TestCase):
         tokens = repository_citations(text)
         self.assertEqual(tokens, ["tools/this_file_does_not_exist.py"])
         self.assertTrue(unresolved(tokens[0], REPO_ROOT))
+
+    def test_an_untracked_file_that_exists_locally_does_not_resolve(self) -> None:
+        """The environment-dependence that the round-0 worktree run exposed.
+
+        `.gitignore` itself is tracked, so it cannot serve as the fixture; a path under a
+        gitignored directory is present in the author's checkout and absent from a clone.
+        Judging by `Path.exists()` made this check pass here and fail everywhere else.
+        """
+        self.assertTrue(unresolved("workspace/orchestrations", REPO_ROOT))
+        self.assertFalse(unresolved("tools/hooks", REPO_ROOT))
+
+    def test_a_deliberately_untracked_citation_is_exempt_by_name(self) -> None:
+        self.assertFalse(unresolved(".claude/settings.local.json", REPO_ROOT))
 
     def test_a_missing_symbol_is_found(self) -> None:
         self.assertTrue(

--- a/tools/tests/test_skill_citations.py
+++ b/tools/tests/test_skill_citations.py
@@ -1,22 +1,30 @@
 #!/usr/bin/env python3
-"""The dev skills under `.claude/skills/` cite this repository; the citations must resolve.
+"""Every repository path the dev skills cite must be one git tracks.
 
-These files are DEV-ONLY — no workflow leaf reads them (`CLAUDE.md` is canonical for that) —
-but they are what an operator and every review subagent are handed, and they are dense with
-pointers into the tree: file paths, `path::symbol` references, and quotations of code. Nothing
-measured them. `.claude/skills/**` matches none of the backend-boundary scanner's globs, and
-the suite reached into that directory only for the one script it owns.
+`.claude/skills/` is DEV-ONLY — no workflow leaf reads it (`CLAUDE.md` is canonical) — but it
+is what an operator and every review subagent are handed, and it is dense with pointers into
+the tree. Nothing measured them: those files match none of the backend-boundary scanner's
+globs, and the suite reached into that directory only for the one script it owns.
 
-Two checks, both narrow on purpose. **A check that parses prose to decide what a claim IS will
-refuse correct writing** — that failure took two rebuilds and a scope declaration on the
-TODO:414 branch — so nothing here reads a sentence. The first check keys on the SHAPE of a
-token (a backticked string starting with a repository directory), the second on a spelling the
-code owns.
+**Scope, stated because the first version of this file claimed more than it did.** This checks
+one thing: a backticked token shaped like a repository path names something git tracks. It does
+NOT check bare identifiers (`some_function`), and it does not verify that a `path::symbol`
+citation's symbol still exists — a first draft did the latter by whole-file substring, which
+resolved `tools/hooks/cli.py::TODO` and the truncated prefix of a renamed symbol, and this
+repository deliberately keeps superseded names in prose, so that check was unsound in the
+direction that matters. Bare-identifier citations were swept by hand at the time this landed
+(108 of them; the three absent were all deliberate negative examples) and are left uncovered
+rather than covered badly.
 
-The second is this repository's own rule applied to the file that states it:
-`metdsl-enforcement-change` rule 3-a says that past three statement sites, a rule's documents
-must be COUPLED to the rule by reading its constant out of the code. That rule is stated in a
-document which quotes the constant. So it is coupled here.
+Two properties the first draft lacked, both found by review:
+
+- **The corpus is discovered from git and its size is asserted.** Moving `references/` out from
+  under a skill made the scan find nothing and pass — an empty corpus satisfies an
+  absence-assertion for ever.
+- **Nothing touches the filesystem.** The first draft asked `Path.exists()`, so a gitignored
+  file present in the author's checkout passed here and failed in every clone; the repair
+  after that still `read_text()` its way to a `FileNotFoundError` on a tree whose index and
+  worktree disagree. Git is asked once, and it is the only thing asked.
 """
 from __future__ import annotations
 
@@ -27,159 +35,178 @@ from functools import lru_cache
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SKILLS = REPO_ROOT / ".claude" / "skills"
+SKILL_ROOT = ".claude/skills"
 
-# A backticked token is treated as a repository citation when it starts with one of these and
-# carries no glob metacharacter or space. That excludes the illustrative paths these documents
-# are full of — `~/.bashrc`, `/etc/hostname`, `docs/**/*.md`, `<repo>/spec/*` — without
-# reading what any sentence is claiming.
-_CITATION_PREFIXES = ("docs/", "tools/", "mcp_servers/", "skills/", ".claude/", "spec/")
-_NOT_A_CITATION = "*?<>| "
-
-
-def repository_citations(text: str) -> list[str]:
-    """Every backticked token in `text` that names a path in this repository."""
-    found = []
-    for token in sorted(set(re.findall(r"`([^`\n]+)`", text))):
-        if not token.startswith(_CITATION_PREFIXES):
-            continue
-        if any(char in token for char in _NOT_A_CITATION):
-            continue
-        # A trailing slash marks a directory in prose (`tools/tests/`); git tracks the
-        # directory under its bare name, so both spellings must reach the same lookup.
-        found.append(token.rstrip(".,;:)").rstrip("/"))
-    return found
-
-
-# Citations to paths this repository deliberately does NOT track. Each is named, with the
-# reason, rather than matched by a pattern: an untracked path is exactly what a stale pointer
-# looks like, so the exemption must be a decision and not a shape.
+# Citations to paths this repository deliberately does NOT track. Named one by one, with the
+# reason: an untracked path is exactly what a stale pointer looks like, so an exemption has to
+# be a decision rather than a shape.
 _UNTRACKED_ON_PURPOSE = {
-    # The operator's machine-local settings layer. The skill names it to say what it is NOT
-    # (not read by a leaf, not consulted by the permission gate), which is why it is cited at
-    # all — and it cannot be tracked without becoming the thing it is contrasted with.
+    # The operator's machine-local settings layer. The skill cites it to say what it is NOT —
+    # not read by a leaf, not consulted by the permission gate — and it cannot be tracked
+    # without becoming the thing it is being contrasted with.
     ".claude/settings.local.json",
 }
 
+# A backticked token carrying one of these is prose, not a pointer: a glob taught as an
+# example, a placeholder, or a sentence fragment.
+_NOT_A_PATH = "*?<>| "
+
+# Skill-relative pointers (`references/verification.md`, `scripts/mutation_check.py`) resolve
+# against the skill that contains them. These are the pointers a reader follows most often and
+# the first draft could not see any of them.
+_SKILL_RELATIVE_ROOTS = ("references/", "scripts/")
+
 
 @lru_cache(maxsize=1)
-def tracked_paths() -> frozenset[str]:
-    """Every path git tracks, plus every directory prefix of one.
-
-    Judged against GIT, not against the filesystem. The first version of this check asked
-    `Path.exists()` and passed in the author's checkout while failing in a fresh worktree,
-    because a gitignored machine-local file happened to be present — the "a test passes
-    because of its own environment" shape this repository has recorded twice. It was caught
-    by the round-0 mutation run, which builds worktrees, and not by the suite.
-    """
+def _git_paths() -> tuple[frozenset[str], frozenset[str]]:
+    """`(tracked files, every directory prefix of one)`, straight from the index."""
     out = subprocess.run(["git", "ls-files", "-z"], cwd=REPO_ROOT,
                          capture_output=True, text=True, check=True).stdout
-    paths = set()
-    for entry in out.split("\0"):
-        if not entry:
-            continue
-        paths.add(entry)
+    files = {entry for entry in out.split("\0") if entry}
+    directories = set()
+    for entry in files:
         parts = entry.split("/")
         for i in range(1, len(parts)):
-            paths.add("/".join(parts[:i]))
-    return frozenset(paths)
+            directories.add("/".join(parts[:i]))
+    return frozenset(files), frozenset(directories)
 
 
-def unresolved(token: str, root: Path) -> str:
-    """"" if the citation resolves, else why it does not."""
-    path, _, symbol = token.partition("::")
-    if path in _UNTRACKED_ON_PURPOSE:
-        return ""
-    if path not in tracked_paths():
-        return "not a tracked path"
-    target = root / path
-    if symbol and symbol.split("::")[0] not in target.read_text(encoding="utf-8"):
-        return "file is tracked but does not contain the symbol"
-    return ""
+def normalize(token: str) -> str:
+    """Strip what prose adds to a path: punctuation, a trailing slash, an anchor, a locator.
+
+    `docs/HOOKS.md#the-rule`, `tools/hooks/cli.py:120` and `tools/hooks/cli.py::_fn` all name
+    the same file; refusing them was an over-refusal on correct writing in the first draft.
+    """
+    token = token.rstrip(".,;:)").rstrip("/")
+    token = token.split("#", 1)[0].split("::", 1)[0]
+    return re.sub(r":\d+$", "", token)
+
+
+def citation_targets(text: str, source: str) -> list[str]:
+    """Every backticked token in `text` that points at a path in this repository.
+
+    A token is a pointer when its first segment is a top-level entry git tracks — derived, not
+    a hand-kept prefix list, which is why `TODO.md`, `AGENTS.md`, `CLAUDE.md` and
+    `leaf_config/` are in scope now and were invisible before — or when it is skill-relative.
+    Returns repository-relative paths, so the caller has one kind of thing to check.
+    """
+    files, _directories = _git_paths()
+    top_level = {entry.split("/")[0] for entry in files}
+    skill_dir = Path(source).parent
+    if skill_dir.parent.as_posix() != SKILL_ROOT:      # a file under references/ or scripts/
+        skill_dir = skill_dir.parent
+    targets = []
+    for raw in sorted(set(re.findall(r"`([^`\n]+)`", text))):
+        if any(char in raw for char in _NOT_A_PATH):
+            continue
+        token = normalize(raw)
+        if not token:
+            continue
+        if token.startswith(_SKILL_RELATIVE_ROOTS):
+            targets.append((skill_dir / token).as_posix())
+        elif token.split("/")[0] in top_level:
+            targets.append(token)
+    return targets
+
+
+def is_tracked(path: str) -> bool:
+    files, directories = _git_paths()
+    return path in _UNTRACKED_ON_PURPOSE or path in files or path in directories
+
+
+@lru_cache(maxsize=1)
+def skill_documents() -> tuple[str, ...]:
+    files, _directories = _git_paths()
+    return tuple(sorted(f for f in files
+                        if f.startswith(SKILL_ROOT + "/") and f.endswith(".md")))
 
 
 class SkillCitationTests(unittest.TestCase):
 
-    def test_every_repository_path_a_skill_cites_resolves(self) -> None:
+    def test_every_repository_path_a_skill_cites_is_tracked(self) -> None:
         """A pointer nobody can follow is worse than no pointer.
 
         These documents are read by subagents that cannot ask a question. On the issue #71
-        branch, three places asserted that `TODO.md` carried a measurement harness while it
-        carried a pointer to a file that had never been in this repository, and four sites
-        named a production caller no callable answers to.
+        branch three places asserted that `TODO.md` carried a measurement harness while it
+        carried a pointer to a file that had never been in this repository.
         """
         broken = []
-        for path in sorted(SKILLS.rglob("*.md")):
-            text = path.read_text(encoding="utf-8")
-            for token in repository_citations(text):
-                why = unresolved(token, REPO_ROOT)
-                if why:
-                    broken.append(f"{path.relative_to(REPO_ROOT)}: `{token}` — {why}")
+        for document in skill_documents():
+            text = (REPO_ROOT / document).read_text(encoding="utf-8")
+            for target in citation_targets(text, document):
+                if not is_tracked(target):
+                    broken.append(f"{document}: `{target}` is not a tracked path")
         self.assertEqual(broken, [], "\n".join(broken))
 
-    def test_the_glob_trigger_quoted_by_the_skill_is_the_one_the_hook_uses(self) -> None:
-        """Rule 3-a, applied to the document that states it.
+    def test_the_corpus_is_not_empty(self) -> None:
+        """An absence-assertion over nothing passes for ever.
 
-        The rule says: past three statement sites, read the rule's constant out of the code
-        and require every statement to name it. `SKILL.md` quotes the `Glob` pattern trigger
-        as the worked example. If the hook's trigger changes, that example becomes one more
-        document stating a rule wrongly — which is the exact failure the rule exists to stop,
-        occurring inside its own explanation.
+        Measured: moving `references/` out from under a skill made the check above find zero
+        citations and report success with a deliberately broken pointer in place. The floor is
+        well under today's figures so ordinary editing does not trip it, and it is a floor
+        rather than an equality because these documents are edited constantly.
         """
-        hook = (REPO_ROOT / "tools" / "hooks" / "cli.py").read_text(encoding="utf-8")
-        match = re.search(r"pattern\.startswith\(\(([^)]*)\)\)", hook)
-        self.assertIsNotNone(match, "the pattern trigger is no longer a startswith tuple")
-        assert match is not None
-        spelling = f"pattern.startswith(({match.group(1)}))"
-        skill = (SKILLS / "metdsl-enforcement-change" / "SKILL.md").read_text(encoding="utf-8")
-        # `assertTrue`, not `assertIn`: the failure message of `assertIn` prints the whole
-        # haystack, and the haystack here is a 700-line document. A check whose failure has
-        # to be scrolled past is a check that gets weakened rather than answered.
-        self.assertTrue(
-            spelling in skill,
-            f"the skill quotes a trigger the hook no longer uses; the hook's is {spelling!r}")
+        documents = skill_documents()
+        self.assertGreaterEqual(len(documents), 6, documents)
+        total = sum(len(citation_targets((REPO_ROOT / d).read_text(encoding="utf-8"), d))
+                    for d in documents)
+        self.assertGreaterEqual(total, 30, f"only {total} citations found — is the scan live?")
 
 
 class CitationScannerSelfTests(unittest.TestCase):
-    """SELF-TEST. Both checks above assert an ABSENCE of findings, so a scanner that found
-    nothing at all would pass them for ever. The rule is defined once, above, and driven here
-    from both sides — one text that must produce a finding and one that must not."""
+    """SELF-TEST. The check above asserts an ABSENCE, so a scanner that found nothing would
+    satisfy it. The rule is defined once, above, and driven here from both directions."""
+
+    _SOURCE = f"{SKILL_ROOT}/metdsl-enforcement-change/SKILL.md"
 
     def test_a_broken_citation_is_found(self) -> None:
-        text = "see `tools/this_file_does_not_exist.py` for the procedure"
-        tokens = repository_citations(text)
-        self.assertEqual(tokens, ["tools/this_file_does_not_exist.py"])
-        self.assertTrue(unresolved(tokens[0], REPO_ROOT))
+        targets = citation_targets("see `tools/no_such_file.py`", self._SOURCE)
+        self.assertEqual(targets, ["tools/no_such_file.py"])
+        self.assertFalse(is_tracked(targets[0]))
 
-    def test_an_untracked_file_that_exists_locally_does_not_resolve(self) -> None:
-        """The environment-dependence that the round-0 worktree run exposed.
-
-        `.gitignore` itself is tracked, so it cannot serve as the fixture; a path under a
-        gitignored directory is present in the author's checkout and absent from a clone.
-        Judging by `Path.exists()` made this check pass here and fail everywhere else.
-        """
-        self.assertTrue(unresolved("workspace/orchestrations", REPO_ROOT))
-        self.assertFalse(unresolved("tools/hooks", REPO_ROOT))
+    def test_a_path_untracked_but_present_locally_is_not_accepted(self) -> None:
+        """The environment-dependence a round-0 worktree run exposed: `workspace/` is
+        gitignored and populated in a working checkout, absent from a clone."""
+        self.assertFalse(is_tracked("workspace/orchestrations"))
+        self.assertTrue(is_tracked("tools/hooks"))
 
     def test_a_deliberately_untracked_citation_is_exempt_by_name(self) -> None:
-        self.assertFalse(unresolved(".claude/settings.local.json", REPO_ROOT))
+        self.assertTrue(is_tracked(".claude/settings.local.json"))
 
-    def test_a_missing_symbol_is_found(self) -> None:
-        self.assertTrue(
-            unresolved("tools/hooks/cli.py::_no_such_symbol_here", REPO_ROOT))
-        self.assertFalse(
-            unresolved("tools/hooks/cli.py::_evaluate_grep_glob_read_policy", REPO_ROOT))
+    def test_top_level_files_and_skill_relative_pointers_are_in_scope(self) -> None:
+        """The three shapes the first draft's hand-kept prefix list could not see."""
+        targets = citation_targets(
+            "`TODO.md`, `AGENTS.md` and `references/verification.md`", self._SOURCE)
+        # Order-insensitive: the question is scope, and coupling it to the sort order of raw
+        # tokens would make an unrelated rename of one of them fail this row.
+        self.assertCountEqual(
+            targets,
+            ["AGENTS.md", "TODO.md",
+             f"{SKILL_ROOT}/metdsl-enforcement-change/references/verification.md"])
 
-    def test_illustrative_paths_are_not_treated_as_citations(self) -> None:
-        """The over-refusal direction, which is the one that makes a check get deleted.
+    def test_a_skill_relative_pointer_resolves_from_a_reference_file_too(self) -> None:
+        source = f"{SKILL_ROOT}/metdsl-enforcement-change/references/verification.md"
+        self.assertEqual(
+            citation_targets("`scripts/measure_claude_tool.py`", source),
+            [f"{SKILL_ROOT}/metdsl-enforcement-change/scripts/measure_claude_tool.py"])
 
-        These documents teach by quoting patterns and host paths. Reading `~/.bashrc` or
-        `docs/**/*.md` as a citation would fail the suite for correct writing, and the fix
-        would be to weaken the check rather than the prose.
+    def test_prose_that_only_looks_like_a_path_is_not_a_citation(self) -> None:
+        """The over-refusal direction, which is what gets a check deleted rather than fixed.
+
+        These documents teach by quoting globs, host paths and placeholders. Reading them as
+        pointers would fail the suite for correct writing.
         """
-        text = ("`~/.bashrc` and `/etc/hostname` read, while `docs/**/*.md`, `<repo>/spec/*` "
-                "and `tools/hooks/cli.py` are different shapes")
-        self.assertEqual(repository_citations(text), ["tools/hooks/cli.py"])
+        text = ("`~/.bashrc` and `/etc/hostname` read, while `docs/**/*.md`, `<repo>/spec/*`, "
+                "`skills/workflow-<step>/SKILL.md` and `tools/hooks/cli.py` differ")
+        self.assertEqual(citation_targets(text, self._SOURCE), ["tools/hooks/cli.py"])
+
+    def test_an_anchor_or_a_line_number_does_not_break_a_citation(self) -> None:
+        for spelling in ("docs/HOOKS.md#the-rule", "docs/HOOKS.md:14", "docs/HOOKS.md::absolute",
+                         "tools/tests/"):
+            with self.subTest(spelling):
+                targets = citation_targets(f"`{spelling}`", self._SOURCE)
+                self.assertEqual(len(targets), 1, spelling)
+                self.assertTrue(is_tracked(targets[0]), spelling)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #71. That branch ran 15 review rounds; step 7 of `metdsl-enforcement-change` says to judge at the end whether the session made the skill stale or exposed a gap. It exposed four, each justified by a failure that **recurred after the existing rule had already been applied**.

## What lands

**`metdsl-enforcement-change` rule 3-a — when the sweep keeps losing, couple the documents to the rule with a check.** Rule 3 ("sweep the prose that cites the rule") is a discipline, and on #71 it failed four consecutive rounds *after round 11 diagnosed it*. Worst instance: the hook refuses a `Glob` pattern beginning with `/` or `~`, five canonical statements said "ONLY when it is ABSOLUTE", and `~` is not absolute — so `docs/AGENT_CONTRACT.md`, the one document every leaf reads, told a leaf that a refusal it can actually receive cannot happen. The rule points at the three coupling tables this repository already has, names their three traps and their three *different* shapes, and gives the members / pointer / number choice. It also says to prefer the cheaper move first — one canonical statement, everyone else cites it — and names the sites a check cannot reach.

**§3 gains the two questions about a remedy that surface 6 did not ask.** Surface 6 asks what a remedy *rewrites*; these ask what it *means to whoever follows it*. Can it be followed by half — #71's `Glob` refusal read as two options, and a leaf doing the first half is allowed by the hook and gets a silent empty result it reports as absence. And does it name the most *reachable* cause first — the roster check offered a vendor cause when a one-line local `deny` was the shortest path, and following it would have made the check green by having been **widened**.

**`metdsl-review-loop` — "only prose remains" is a claim about severity.** Both existing stopping proxies read as held from round 11 while statements a leaf and an operator *act on* were still wrong. Remaining findings are classified by audience and consequence, with the tell (an imperative, or a condition under which something is refused), and the move that finds them: **one round with both agents on the disclosure axis, run before deciding to stop** — bundled into the correctness axis, doc-truth loses to whatever functional question shares the brief.

**`references/verification.md` — five ways a verification step or a record silently does not hold**, all hit on #71: `cmd | tail && git commit` does not gate on `cmd` (a pipeline exits with its last element's status; this put a commit on a red suite), `git -C <repo> worktree add <rel>` resolves against the repo so `git add -A` commits a gitlink, a multi-edit script that asserts before writing loses the whole batch silently (three recurrences, each producing a commit message claiming work `git log -S` cannot find), mutation survivors must be named individually, and a committed instrument needs a machine-readable verdict and its own test.

Plus `tools/tests/test_skill_citations.py`: every backticked repository path in the skills must be a path git tracks. 9 documents, 54 citations.

## Review — three rounds, and every round's findings sat in the previous round's fix

This is the disclosure the loop asks for, and it is unusually on-point because the defects were instances of the rules being added.

**Round 0** (mutation) caught the check I had just written passing for its own environment: `.claude/settings.local.json` is cited by the skill, is deliberately gitignored, and *exists here*, so `Path.exists()` was green in my checkout and red in every clone.

**Round 1** found six, four of them instances of the added rules:
- `git worktree add -C <repo>` **is not a command** (`unknown switch 'C'`) — a mis-transcribed command in the file that says to execute what you write, in the commit adding that rule;
- "the only document a leaf reads" is **false** (five documents are leaf force-reads) — written twice by this branch;
- rule 3-a described a mechanism the repository already has **three times**, citing none of them, and claimed to be surface 5's twin when it is its opposite; its threshold was decorative ("three sites OR one read by a leaf/operator" drops it to one); it only worked for a small literal set;
- three statements of one threshold with two different remedies, across both skills — rule 3 broken by rule 3-a;
- the Surface 6 addendum was a twin of §3's existing rule;
- "zero functional defects for four rounds" was not true.

**Round 2** found ten more, including the sharpest:
- **the property round 1 said it had fixed was fixed on one side only.** The path set moved to git; the *content* stayed `read_text`, so the `FileNotFoundError` the docstring claims to have repaired still reproduced. Bodies now come from `git show :<path>`.
- **two round-1 repairs had no witness and their mutations survived**: reverting `is_tracked` to `Path.exists()` left every row green in a clone (the witness depended on a gitignored directory happening to exist), and the corpus floor passed with a **third of the corpus dropped**. Both now have witnesses that hold in every checkout; the index-versus-worktree property is witnessed by *building* a tree where the two disagree.
- **the exemplar rule 3-a tells you to copy failed 3-a's own trap**: `_trigger_prefixes` matched only an inline tuple, so extracting the literal to a named constant turned a set of true documents red with no repair named. Round 1 deleted my own copy of that pin for exactly this reason and pointed readers at the original. Fixed, and witnessed by performing the extraction.
- a self-contradiction twenty lines below the paragraph I had corrected; one clause duplicated four lines apart in one paragraph; "canonical for both thresholds" false; "nine histories" become ten; "nineteen-entry environment allowlist" (it has nine — nineteen is the other branch's *tool roster*); `docs/examples/*.yaml` cited as an unreachable site when a test closed that drift; a heading saying "two ways" over five items.

One accounting correction to my own round-1 commit: the timed-out-launch defect was **introduced by my fix**, not found by round 15, so the committed script had one functional defect found, not two.

## What is not done

- **Always-loaded cost grew ~10.7 KB (+10%)**: `metdsl-enforcement-change/SKILL.md` 38,978 → 45,522 B, `metdsl-review-loop/SKILL.md` 66,768 → 70,949 B. Nothing gates this — no size ceiling covers `.claude/skills/`, and the skill says so itself. A reviewer's concrete proposal, **not taken here**, is to move rule 3-a's mechanism half (the traps, the table shapes, the members/pointer/number choice) to a `references/` file, leaving the trigger and the cheaper-fix sentence in SKILL.md.
- Two larger, **pre-existing** reduction opportunities the same reviewer measured and I did not touch: the Fortran spelling checklist (~32 lines, applies to one file, already on the debt ledger) and the round-0 mutation bullet list (~160 lines, whose episodes duplicate `references/mutation-testing.md`).
- The citation check covers path-shaped citations only. Bare identifier citations were swept by hand (108; the three absent were deliberate negative examples) and are left uncovered rather than covered badly — a `path::symbol` check by whole-file substring resolved `cli.py::TODO` and the truncated prefix of a renamed symbol, and this repository deliberately keeps superseded names in prose.

Verification at HEAD: suite **5184 passed**; the three mutations that survived at the start of round 2 are each killed by exactly one row; ruff equal to `origin/main` per file (the one remaining error is pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rugg4GYAJBFJYoqQPs25AA
