### PR TITLE
metdsl-review-loop: three rules PR #98 paid for, and one review round that corrected the first draft

### DIFF
--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -74,15 +74,9 @@ python3 .claude/skills/metdsl-review-loop/scripts/mutation_check.py \
 #   --range origin/main...HEAD
 ```
 
-**Pass `-x` — but only once you know the baseline is green FOR THE TEST COMMAND YOU PASS.**
-The exit code decides the verdict, and `-x` stops at the first failure: if the suite already has
-one that is nothing to do with your change, every mutant stops there and every mutant reads as
-`killed`. That is a false green over the whole run, not a per-hunk slip. In met-dsl the standing
-instance is the two path-depth-coupled `ForbidBackendCredentialReadTests` cases, which fail in a
-worktree under `/tmp` and pass in the checkout — so the script's own baseline goes red (exit 2)
-and tells you, but a HANDWRITTEN sweep in a scratch copy will not. **Deselect the known failures
-in `--test-cmd`, or drop `-x`.** The output is otherwise read only to tell a real failure from a
-suite that never ran. Hunks run in separate worktrees, `min(cores - 2, 4)` at a
+**Pass `-x` — but only with a `--test-cmd` whose baseline is green** (see the handwritten-sweep
+bullet below, which is where that bites). The exit code decides the verdict — the output is read
+only to tell a real failure from a suite that never ran. Hunks run in separate worktrees, `min(cores - 2, 4)` at a
 time by default and never more than the hunk count (`--jobs`); 4 hunks × 805 tests measured 5m52s → 43s. **Do not put a `TMPDIR=` prefix in
 `--test-cmd`**: each job already gets its own temp root, a prefix puts them all back on one, and
 failures then belong to no hunk and are recorded as `killed` — a false pin (at more than one job
@@ -108,8 +102,14 @@ when a rule does not obviously apply:
   when you do** — a mutant can kill pytest during collection and a `FAILED`-line scorer reads
   that as green (PR #68: 3 mutants hid 41-47 real failures). Put both facts in the reviewer's
   instructions too
-- **Run the baseline for handwritten sweeps too** — a stale worktree makes a red baseline look
-  like every mutant was killed (PR #67)
+- **Run the baseline for handwritten sweeps too, and read it before you trust `-x`** — the script
+  refuses a red baseline (exit 2); a sweep you write yourself will not. Two causes, same false
+  green: a stale worktree (PR #67), and a suite that ALREADY has a failure unrelated to the change,
+  where `-x` stops every mutant at that same failure so every mutant reads as `killed` — a false
+  green over the whole run, not a per-hunk slip. met-dsl's standing instance is the two
+  path-depth-coupled `ForbidBackendCredentialReadTests` cases, which fail in a worktree under
+  `/tmp` and pass in the checkout; one PR #98 reviewer reported 12 of 12 mutants killed that way
+  before re-running. **Deselect the known failures in `--test-cmd`, or drop `-x`**
 - **If the change is a move, hunk mutation answers almost nothing** — `--range` cannot reach code
   that moved without changing. For move / rename / extract PRs build **mechanism-level mutants
   over every mechanism in the files you touched** (PR #68: my 39 mutants, 0 unexpected survivors;
@@ -173,13 +173,9 @@ when a rule does not obviously apply:
     has a witness, the property holding it up usually does not
   - **kill enumerations one element at a time** (regex alternatives, keyword tables); checked
     together, a missing element goes unnoticed
-  - **generating the probes FROM the constant gives set identity, not a family that can
-    distinguish anything.** A table-driven test that builds one input per member is the right
-    shape — a member added without a probe gets one — but the SPELLING you generate can be the
-    one shape every member survives. Ask of the generated family: *is there a member for which
-    this input could not fail?* Then check that the spelling is one the thing under test actually
-    accepts. PR #98 shipped three of these, one per round, and each was reported as having settled
-    the question it could not reach. Episode: `references/mutation-testing.md`
+  - **generating the probes FROM a constant gives set identity, not a family that can distinguish
+    anything** — the sign "you measured a family and reported the conclusion" below carries the
+    two checks; reach for it whenever a table-driven test is the evidence you are about to cite
   - **one test per occurrence of a rule, not per rule** — and **the sharpest trigger is a TWIN**:
     when a change touches one of a matched pair, list the pair, list your witnesses, compare the
     two lists before handing over
@@ -205,6 +201,12 @@ when a rule does not obviously apply:
      figure depends on the diff CONTEXT WIDTH. Name the width, the command, and the exclusions
    - **Recording that a number "was right when written" does not stop the next rot.** Only
      changing the form stopped it
+   - **And then verify the substitution RAN.** The remedy has its own failure mode: PR #98 escalated
+     to scripted substitution after four hand-typed numbers came out wrong, and the very next commit
+     shipped with **eight unsubstituted `{PLACEHOLDER}` tokens in its message**, directly under the
+     sentence saying the numbers were no longer typed (an f-string ate the doubled braces). Assert
+     that no placeholder survives before you commit — one `re.search` — because a message cannot be
+     fixed after it is pushed, and this failure looks exactly like success
 
    Episodes: `references/measurement-records.md`.
 
@@ -341,10 +343,13 @@ replacing one.
 
 **Work you may delegate (verifiable = running it settles the truth)**: re-measuring every number
 in the diff **and reporting mismatches**; back-checking "recorded in X" / "pinned by Y" /
-"covered by Z" (grep for existence, then **delete what the test is ABOUT and see the test
-fail** — deleting the test itself proves nothing, since removing a passing `unittest` method can
-never turn another one red, and a reviewer who reads that instruction literally will report the
-whole axis as vacuous, correctly); a correspondence
+"covered by Z" (grep for existence, then **delete what the test is ABOUT and see the test fail**
+— deleting the test itself USUALLY proves nothing, since removing a passing `unittest` method
+usually cannot turn another one red, and a reviewer who reads that instruction literally will
+report the whole axis as vacuous. Not always, though, and the exceptions are worth knowing: two
+rows here DO notice a deleted sibling — `AgentRoleFailClosedTests::test_this_class_census_is_accurate`
+compares an in-class census against `dir(type(self))`, and `SkillReachabilityTests._run_row`
+constructs a test by name); a correspondence
 table of whether each new failure class has a test; counting the call sites that make the same
 decision; contradictions between prose and implementation.
 
@@ -370,6 +375,12 @@ and "accepted residual". It saves tokens and **propagates your own errors with i
 P1 survived five rounds inside that list (two reviewers had found it, and an unverified premise
 had dropped it into residual).
 
+- **Your own RESIDUE list rots the same way, and nothing above covers it.** A published "what this
+  does not catch" list is read as a completeness claim — `docs/RUNBOOK.md` pointed an operator at
+  one — so re-verify every entry each round, in BOTH directions: an entry that is no longer residue,
+  and a route the list calls covered that is not. On PR #98 the list omitted its largest member for
+  two rounds and asserted the interpreter route was covered for three, and round 5 established that
+  route was the widest gap on the branch
 - Hand over an exclusion list **for at most three rounds**
 - From round four, **run at least one reviewer with no exclusions**: "you get no history — attack
   from scratch"
@@ -495,6 +506,14 @@ cut, and it runs both ways:
   on the "false evidence" side
 - **rough edges in existing behaviour this PR does not touch** — file them in TODO.md and hand
   them over. Pulling them in compounds "fixes calling for fixes"
+
+**When the change ADDS A REFUSAL, read the remedy texts of the neighbouring guards.** A sibling's
+remedy can steer the refused party straight onto the route you did not close, and then the hole is
+not in your rule but in what the surrounding system tells someone to do instead. On PR #98 the new
+refusal's own residue was "a writer inside a script FILE handed to an interpreter" — and
+`forbid_python_inline_write`'s block text says "use a real script file (`python3 script.py`)", over
+an allow-list entry that permits exactly that and a leaf-read document that teaches it. Three
+sources agreeing on a route none of them guards is not something any single-file review sees.
 
 **Two questions when in doubt**, both of which must answer yes: "if this stays unfixed and one
 `workflow` runs, does a **wrong certification** or a **false record** come out?" and "**does a leaf
@@ -726,14 +745,25 @@ that tells you how it closed.
   automatically true via another clause (`"cmake"` contains `"make"`). **Assert inside the test
   that the probe has the property it needs**
 - **You measured a family and reported the conclusion** → ask whether the family could have come
-  out the other way. The criterion is one question: **name a member for which the measurement
-  could have failed.** If you cannot, you measured a family that structurally cannot answer, and
-  the conclusion is unsupported however many members it had — 48 spellings, 8 spellings and 17
-  spellings each did this on PR #98. It is not the substring sign above: there the single probe
-  is degenerate; here every probe is fine and the SET is chosen from one corner. **The most
-  dangerous version is a generated probe that is not a spelling the thing under test accepts at
-  all** (`timeout cp a b` is not valid bash), because then the test is green on an input that
-  cannot occur. The three families and how each was closed: `references/mutation-testing.md`
+  out the other way. **Two checks, and the second is the one that finds things.** (a) Name a member
+  for which the measurement could have failed; if you cannot, you measured a family that
+  structurally cannot answer, however many members it had — 48 spellings, 8 spellings and 8
+  spellings each did this on PR #98. (b) **Is the generated spelling one the ACCEPTING PARTY takes?**
+  The accepting party is whatever produces the input in production, and it is often not the code
+  under test: for a wrapper table it is bash (`timeout cp a b` parses fine and `timeout(1)` then
+  refuses it, so the row is inert), for a detector fed arbitrary argv it is the detector itself, for
+  a source-text scan it is Python's grammar. Check (a) cleared a real defect on this repo's own
+  corpus that (b) caught — a restatement scan generating one quote style where the neighbouring
+  test loops both. This is the generated-family case of **"a hand-built fixture can test a shape
+  that does not exist"** above; that bullet is the same rule for a hand-written probe.
+  **Carve-out**: a loop asserting a property every member is SUPPOSED to have (`assertTrue(name.strip())`
+  over a curated constant) is a future-guard, not a measurement — no current member can fail by
+  construction and that is the point. The checks apply when you are reporting a conclusion FROM the
+  family. **And the family can generate a degenerate member**: `'verdict.json'` is a substring of
+  `'aggregate_verdict.json'` in the same tuple, so the substring sign above and this one compose —
+  check members against EACH OTHER, not only against the implementation. The remedies differ
+  (`assertNotIn(implemented_id, probe)` vs. widening the family), so name both when they overlap.
+  Episodes, including a 13-family sweep of this repository's own tests: `references/mutation-testing.md`
 
 ## Finally
 

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -74,8 +74,15 @@ python3 .claude/skills/metdsl-review-loop/scripts/mutation_check.py \
 #   --range origin/main...HEAD
 ```
 
-**Pass `-x`.** The exit code decides the verdict — the output is read only to tell a real
-failure from a suite that never ran. Hunks run in separate worktrees, `min(cores - 2, 4)` at a
+**Pass `-x` — but only once you know the baseline is green FOR THE TEST COMMAND YOU PASS.**
+The exit code decides the verdict, and `-x` stops at the first failure: if the suite already has
+one that is nothing to do with your change, every mutant stops there and every mutant reads as
+`killed`. That is a false green over the whole run, not a per-hunk slip. In met-dsl the standing
+instance is the two path-depth-coupled `ForbidBackendCredentialReadTests` cases, which fail in a
+worktree under `/tmp` and pass in the checkout — so the script's own baseline goes red (exit 2)
+and tells you, but a HANDWRITTEN sweep in a scratch copy will not. **Deselect the known failures
+in `--test-cmd`, or drop `-x`.** The output is otherwise read only to tell a real failure from a
+suite that never ran. Hunks run in separate worktrees, `min(cores - 2, 4)` at a
 time by default and never more than the hunk count (`--jobs`); 4 hunks × 805 tests measured 5m52s → 43s. **Do not put a `TMPDIR=` prefix in
 `--test-cmd`**: each job already gets its own temp root, a prefix puts them all back on one, and
 failures then belong to no hunk and are recorded as `killed` — a false pin (at more than one job
@@ -166,6 +173,13 @@ when a rule does not obviously apply:
     has a witness, the property holding it up usually does not
   - **kill enumerations one element at a time** (regex alternatives, keyword tables); checked
     together, a missing element goes unnoticed
+  - **generating the probes FROM the constant gives set identity, not a family that can
+    distinguish anything.** A table-driven test that builds one input per member is the right
+    shape — a member added without a probe gets one — but the SPELLING you generate can be the
+    one shape every member survives. Ask of the generated family: *is there a member for which
+    this input could not fail?* Then check that the spelling is one the thing under test actually
+    accepts. PR #98 shipped three of these, one per round, and each was reported as having settled
+    the question it could not reach. Episode: `references/mutation-testing.md`
   - **one test per occurrence of a rule, not per rule** — and **the sharpest trigger is a TWIN**:
     when a change touches one of a matched pair, list the pair, list your witnesses, compare the
     two lists before handing over
@@ -327,7 +341,10 @@ replacing one.
 
 **Work you may delegate (verifiable = running it settles the truth)**: re-measuring every number
 in the diff **and reporting mismatches**; back-checking "recorded in X" / "pinned by Y" /
-"covered by Z" (grep for existence; **delete the test and see it fail**); a correspondence
+"covered by Z" (grep for existence, then **delete what the test is ABOUT and see the test
+fail** — deleting the test itself proves nothing, since removing a passing `unittest` method can
+never turn another one red, and a reviewer who reads that instruction literally will report the
+whole axis as vacuous, correctly); a correspondence
 table of whether each new failure class has a test; counting the call sites that make the same
 decision; contradictions between prose and implementation.
 
@@ -684,7 +701,12 @@ that tells you how it closed.
 - **The same mechanism keeps being broken for three rounds or more** → suspect that **the question
   the rule is trying to answer** cannot be answered at this level of analysis; change to a weaker
   question that can be. **If the simple and the complex version give identical measured diffs, the
-  complexity bought nothing**
+  complexity bought nothing.** When the defects are all ONE shape rather than a spread, reach for
+  this before the five-round "the shape of the rule is wrong" count below — on PR #98 it was the
+  correct read at three. **Changing the question is a shape change, so it is split-or-ask**, and
+  **it buys no smaller review surface**: the replacement mechanism drew two more rounds of HIGH
+  findings, one of them a fail-open regression against `origin/main`
+  (`references/class-descent-log.md`)
 - **A reviewer said "it is environment-dependent"** → do not close it with a mock on the test side.
   Ask first what happens in production on that environment (`metdsl-enforcement-change` rule 2
   owns this)
@@ -703,6 +725,15 @@ that tells you how it closed.
 - **A witness test's probe value contains the implemented value as a substring** → the assertion is
   automatically true via another clause (`"cmake"` contains `"make"`). **Assert inside the test
   that the probe has the property it needs**
+- **You measured a family and reported the conclusion** → ask whether the family could have come
+  out the other way. The criterion is one question: **name a member for which the measurement
+  could have failed.** If you cannot, you measured a family that structurally cannot answer, and
+  the conclusion is unsupported however many members it had — 48 spellings, 8 spellings and 17
+  spellings each did this on PR #98. It is not the substring sign above: there the single probe
+  is degenerate; here every probe is fine and the SET is chosen from one corner. **The most
+  dangerous version is a generated probe that is not a spelling the thing under test accepts at
+  all** (`timeout cp a b` is not valid bash), because then the test is green on an input that
+  cannot occur. The three families and how each was closed: `references/mutation-testing.md`
 
 ## Finally
 

--- a/.claude/skills/metdsl-review-loop/references/class-descent-log.md
+++ b/.claude/skills/metdsl-review-loop/references/class-descent-log.md
@@ -64,6 +64,53 @@ here", attempted by regex, was broken 16 ways; "is there no other declaration an
 closed it. If the simple and the complex version produce identical measured diffs, the complexity
 bought nothing — take that diff first.
 
+## PR #98 — the weaker question, applied mid-loop, and the class that never descended
+
+The second recorded instance of L128's move, and the first where the redesign happened INSIDE a
+running loop rather than after it.
+
+`TODO.md` 378(d) asked "which operand does this `cp` write?" — extractable only by re-implementing
+bash's word splitting plus each tool's getopt grammar. Rounds 1, 2 and 3 each found the same defect
+one function further on: a value read off one copy of the command while a decision was made on
+another (`shlex`-token segmentation vs. the read side's string split; operands read from the raw
+command while segmentation ran on a sanitized one; a substitution marked at its first byte, with
+its spans located on the copy where they had been erased). Every fix regenerated the family, in
+both directions at once — `cp src dst 2>/dev/null` refused naming the path `2`, `cd x; cp a
+<managed path>` extracting nothing at all.
+
+**The trigger fired at THREE rounds, not five.** SKILL.md's count for "the shape of the rule is
+wrong" is five; the sibling sign — "the same mechanism keeps being broken for three rounds or more
+→ change to a weaker question" — is the one that was right here, and it is the one to reach for
+first when the defects are all one shape rather than a spread.
+
+The weaker question: **stop naming the destination, recognise the command.** "Is the head of this
+fragment a command that writes a file?" is one lookup. It closed the family structurally — every
+spelling that had defeated the parser is caught, because none of them has to be modelled to read a
+head — and it flipped the failure direction from open to closed.
+
+**Two things this episode shows that L128 does not.**
+
+- **The redesign was put to the USER, not taken.** SKILL.md's rule for a fix that changes the shape
+  of the rule is split-or-ask; the options offered were split the branch / continue / redesign in
+  place, with the measured basis (every finding traced to the argv grammar or to a regex widening
+  done to serve it; the redirect half had produced no finding since round 1). The user chose
+  redesign. Taking that decision silently would have been the same class of error as the loop's own
+  defects.
+- **A weaker question is not a smaller review surface.** The new mechanism got rounds 4 and 5, and
+  each found HIGH defects IN IT — a wrapper hop broken for six of eight wrappers by their own
+  canonical invocations, then `[[ … ]]` matched outside command position blanking a real redirect
+  (a fail-open REGRESSION against `origin/main`, introduced by round 4's own fix). **The class
+  never descended across all five rounds.** The loop ended at the cap, disclosed as not converged.
+
+**What the remainder looked like at the cap**, and why it was disclosed rather than fixed: the
+widest gap was a writer inside a script FILE handed to any interpreter (`bash x.sh`,
+`python3 x.py`), which no guard covers — and which a SIBLING guard's remedy text actively steers a
+refused leaf toward, over an allow-list entry that permits it. That is worth reading twice: the
+review found not a hole in the new rule but a hole the surrounding system's own instructions point
+at. Two reviewers' corpus differentials (283 real leaf commands, 51,425 operator commands, ~4,000
+generated redirect spellings) found no lost target and no refusal of real leaf work versus
+`origin/main`, which is what bounded the remainder well enough to stop.
+
 ## PR #53 — the last round changed one behaviour
 
 "Holes in the mechanism itself; a deleted defense is reachable" → "missed spellings and contexts

--- a/.claude/skills/metdsl-review-loop/references/class-descent-log.md
+++ b/.claude/skills/metdsl-review-loop/references/class-descent-log.md
@@ -74,9 +74,9 @@ bash's word splitting plus each tool's getopt grammar. Rounds 1, 2 and 3 each fo
 one function further on: a value read off one copy of the command while a decision was made on
 another (`shlex`-token segmentation vs. the read side's string split; operands read from the raw
 command while segmentation ran on a sanitized one; a substitution marked at its first byte, with
-its spans located on the copy where they had been erased). Every fix regenerated the family, in
-both directions at once — `cp src dst 2>/dev/null` refused naming the path `2`, `cd x; cp a
-<managed path>` extracting nothing at all.
+its spans located on the copy where they had been erased). Every fix regenerated the family, and in
+rounds 1 and 2 in both directions at once — `cp src dst 2>/dev/null` refused naming the path `2`,
+`cd x; cp a <managed path>` extracting nothing at all. Round 3's were over-refusal only.
 
 **The trigger fired at THREE rounds, not five.** SKILL.md's count for "the shape of the rule is
 wrong" is five; the sibling sign — "the same mechanism keeps being broken for three rounds or more
@@ -93,11 +93,15 @@ head — and it flipped the failure direction from open to closed.
 - **The redesign was put to the USER, not taken.** SKILL.md's rule for a fix that changes the shape
   of the rule is split-or-ask; the options offered were split the branch / continue / redesign in
   place, with the measured basis (every finding traced to the argv grammar or to a regex widening
-  done to serve it; the redirect half had produced no finding since round 1). The user chose
-  redesign. Taking that decision silently would have been the same class of error as the loop's own
+  done to serve it). **The basis as put to the user overstated one half**: it said the redirect side
+  had produced no finding since round 1, and round 2 had two (`2>&-` reported as a write to `-`, and
+  the `startswith("&")` guard deleted for dropping a quoted `> "&1"`) — both arising from a regex
+  widening done for the argv view, which is the qualification that belonged in the sentence. The
+  user chose redesign. Taking that decision silently would have been the same class of error as the loop's own
   defects.
 - **A weaker question is not a smaller review surface.** The new mechanism got rounds 4 and 5, and
-  each found HIGH defects IN IT — a wrapper hop broken for six of eight wrappers by their own
+  each found serious defects IN IT (severities are the reviewers' and mine at the time; the commits
+  record the defects, not a severity field) — a wrapper hop broken for six of eight wrappers by their own
   canonical invocations, then `[[ … ]]` matched outside command position blanking a real redirect
   (a fail-open REGRESSION against `origin/main`, introduced by round 4's own fix). **The class
   never descended across all five rounds.** The loop ended at the cap, disclosed as not converged.

--- a/.claude/skills/metdsl-review-loop/references/mutation-testing.md
+++ b/.claude/skills/metdsl-review-loop/references/mutation-testing.md
@@ -295,15 +295,22 @@ message as having settled the question.
   filter, "measured over eight fd-dup spellings". Every one was written `cp a b 2>&1`. GLUED to the
   operand — `cp a b2>&1` — the filter takes the real destination with it, so the pass was
   load-bearing and the note said the opposite.
-- **17 wrappers, all probed as `f"{name} cp a b"`.** The worst of the three, because it was the
+- **8 wrappers, all probed as `f"{name} cp a b"`.** The worst of the three, because it was the
   set-identity test itself and the commit cited it as answering a census's complaint about
-  sampling. Every wrapper works with no options; six of eight were defeated by their own canonical
-  invocation (`env FOO=1 cp`, `timeout 5 cp`, `sudo -u root cp`, `xargs -I {} cp`), and `timeout`
-  was inert for every spelling that exists, since a valid `timeout` begins with a DURATION.
-  **`timeout cp a b` is not a spelling bash accepts** — the test was green on an input that cannot
-  occur. Fixed with a spelling table asserted to cover the constant, each entry RUN under bash to
-  confirm it performs the write; writing that table caught a fourth instance in itself
-  (`case x in a) cp …` never matches `x`).
+  sampling. Every wrapper works with no options; **six of the eight** were defeated by their own
+  canonical invocation (`env FOO=1 cp`, `timeout 5 cp`, `sudo -u root cp`, `xargs -I {} cp`), and
+  `timeout` was inert for every spelling that exists, since a valid `timeout` begins with a
+  DURATION. **`timeout cp a b` is not an invocation `timeout` accepts** — bash parses it fine
+  (`bash -n` exits 0); `timeout(1)` answers `invalid time interval 'cp'`, rc=125, and writes
+  nothing. The row was green on an input that cannot occur. Fixed with a spelling table asserted to
+  cover the constant, most entries RUN under bash to confirm the write; writing that table caught a
+  fourth instance in itself (`case x in a) cp …` never matches `x`).
+  **Residue in the fix, found by the round that reviewed it**: the fix's docstring says "15 of the
+  17 spellings were run … and confirmed to actually perform the copy", which is one too many —
+  `xargs -I {} cp {} dst` with no stdin exits 0 having copied nothing. The test is still correct
+  (the detector reads words, not behaviour), and the count in the DEFECT above is 8 because that is
+  what the broken table held; 17 is the size of the REPAIRED one. Attributing a fix's number to the
+  defect it fixed is its own small version of this.
 
 **The check is one question**: name a member of the family for which the measurement could have
 come out the other way. Then check the spelling is one the thing under test accepts.
@@ -315,4 +322,23 @@ it: `-x` stopped on the two path-depth-coupled `ForbidBackendCredentialReadTests
 in a `/tmp` worktree and pass in the checkout, so every mutant "killed" the same pre-existing
 failure. `mutation_check.py`'s own baseline catches this (red baseline, exit 2) — a HANDWRITTEN
 sweep in a scratch copy does not. Deselect the known failures in the test command, or drop `-x`.
+The "12 of 12" is that reviewer's own report of their run; it is not reproducible from the tree.
+
+### A revert that reintroduces a SHADOWED duplicate (PR #98, `bb4e915`)
+
+`mutation_check.py` left one unexplained survivor: the hunk DELETING the old
+`_BASH_INPUT_REDIRECT_RE`, whose replacement had moved to the top of the file with a fd prefix
+added. Reverting the deletion re-adds the old definition AFTER the new one, so the old one wins and
+nothing goes red — while the deletion was load-bearing (`cp a b 2<in.txt` yielded a bare `2` as a
+write target without it). This is not the documented "one half of a code move survives": both halves
+are present in the mutant, and the survivor is REAL. **When a definition moved within a file, revert
+its deletion and check which copy wins before reading the survivor as noise.**
+
+### Pinned at the helper, not at the handler (PR #98, `7d3dae9`)
+
+The last survivor of the branch was `cli.main` handing the raw command to the detector. Nothing went
+red because every helper-level test passed the raw command itself — so the wiring could be deleted
+and the suite stayed green. SKILL.md already names the shape ("Pin at the handler, not the helper");
+what this episode adds is that a MUTATION CHECK is what surfaced it, after four review rounds had
+not, and that the tell is a survivor on a one-line call-site hunk.
 

--- a/.claude/skills/metdsl-review-loop/references/mutation-testing.md
+++ b/.claude/skills/metdsl-review-loop/references/mutation-testing.md
@@ -278,3 +278,41 @@ The sub-rules below had no section here and were carried in `SKILL.md` in full. 
     `--help` line and a RUNBOOK entry: mutating rc 3's mapping to `return 1` left **1555 rows
     green**, and three review rounds walked past it. The check is mechanical — **list the pair,
     then list your witnesses, and compare the two lists** before handing over
+
+### A probe family generated from a constant, chosen from the one corner where it cannot fail (PR #98)
+
+Table-driven set identity is the right shape and this branch used it three times. All three
+generated the probe SPELLING from the same corner, and all three were written into a commit
+message as having settled the question.
+
+- **48 spellings, all long options.** A branch of the option loop was deleted as an "equivalent
+  mutant, measured over all 48 spellings the value tables produce". The tables hold 12 long and 12
+  short options; the 48 were 12 long × {before, after, empty value, behind `--`}. The deleted
+  branch could only differ when a SHORT option's cluster split ran, and `arg.startswith("--")`
+  short-circuits that — so no member of the family could have failed. A reviewer built two short
+  `=` witnesses that did distinguish it.
+- **8 fd-dup spellings, all with a leading space.** A pass was documented as subsumed by a later
+  filter, "measured over eight fd-dup spellings". Every one was written `cp a b 2>&1`. GLUED to the
+  operand — `cp a b2>&1` — the filter takes the real destination with it, so the pass was
+  load-bearing and the note said the opposite.
+- **17 wrappers, all probed as `f"{name} cp a b"`.** The worst of the three, because it was the
+  set-identity test itself and the commit cited it as answering a census's complaint about
+  sampling. Every wrapper works with no options; six of eight were defeated by their own canonical
+  invocation (`env FOO=1 cp`, `timeout 5 cp`, `sudo -u root cp`, `xargs -I {} cp`), and `timeout`
+  was inert for every spelling that exists, since a valid `timeout` begins with a DURATION.
+  **`timeout cp a b` is not a spelling bash accepts** — the test was green on an input that cannot
+  occur. Fixed with a spelling table asserted to cover the constant, each entry RUN under bash to
+  confirm it performs the write; writing that table caught a fourth instance in itself
+  (`case x in a) cp …` never matches `x`).
+
+**The check is one question**: name a member of the family for which the measurement could have
+come out the other way. Then check the spelling is one the thing under test accepts.
+
+### `-x` turns a pre-existing failure into a whole-run false green (PR #98)
+
+A reviewer's first mutation pass reported 12 of 12 mutants KILLED, and they re-ran and discarded
+it: `-x` stopped on the two path-depth-coupled `ForbidBackendCredentialReadTests` cases, which fail
+in a `/tmp` worktree and pass in the checkout, so every mutant "killed" the same pre-existing
+failure. `mutation_check.py`'s own baseline catches this (red baseline, exit 2) — a HANDWRITTEN
+sweep in a scratch copy does not. Deselect the known failures in the test command, or drop `-x`.
+

--- a/.claude/skills/metdsl-review-loop/references/signs-episodes.md
+++ b/.claude/skills/metdsl-review-loop/references/signs-episodes.md
@@ -102,4 +102,10 @@ the case history that tells you how it closed.
   "cmake", ...)`'s message contains the implemented `make`, which is always true because **`"cmake"`
   contains `"make"`** (found independently by two reviewers). **Assert inside the test that the
   probe has the property it needs** (`assertNotIn(implemented_id, probe)`)
+- **You measured a family and reported the conclusion** → PR #98 did this three times, once per
+  round, each time in the commit message that announced the fix. The three families and the
+  one-question check are in `references/mutation-testing.md`. What makes it a distinct sign from
+  the substring one above: there a single probe is degenerate and reading it shows that; here every
+  probe is individually fine, and only the SET is wrong — nothing in any one of them looks off, so
+  it survives review by anyone who reads the test rather than asking what the family spans
 

--- a/.claude/skills/metdsl-review-loop/scripts/mutation_check.py
+++ b/.claude/skills/metdsl-review-loop/scripts/mutation_check.py
@@ -34,6 +34,15 @@ first failing test instead of finishing the suite, and keep `--test-cmd` narrowe
 the tests that could plausibly see the change. Measured on a 4-hunk met-dsl range with
 an 805-test file: 5m52s serially without `-x`, 43s with both (21s of that the baseline).
 
+**`-x` is only safe once the baseline for THAT `--test-cmd` is green.** If the command
+you pass already has a failure unrelated to the change, `-x` stops every mutant at it and
+every mutant is recorded `killed` — a false green over the whole run. The baseline check
+below is what protects you (red baseline, exit 2), so heed it rather than reaching for
+`--skip-baseline`; and note the protection does NOT extend to a sweep you write by hand.
+met-dsl's standing instance is the two path-depth-coupled `ForbidBackendCredentialReadTests`
+cases, which fail in a worktree under `/tmp` and pass in the checkout: deselect them in
+`--test-cmd`, or drop `-x`.
+
 A baseline run (nothing reverted) goes first. Without it a suite that is already red
 reports every hunk as "killed" — a false green, and the failure mode of this script that
 reads most like success.

--- a/tools/tests/test_hooks_cli.py
+++ b/tools/tests/test_hooks_cli.py
@@ -5441,8 +5441,14 @@ class BashWriteTargetGrammarTests(unittest.TestCase):
 
         The spelling table is checked against the constant first, so a head added
         to the code without one fails here rather than getting a probe that cannot
-        fail. Each spelling was run under bash in a scratch directory and confirmed
-        to actually perform the copy.
+        fail. 14 of the 17 spellings were run under bash in a scratch directory and
+        confirmed to actually perform the copy. The three that were not: `sudo`
+        (this host wants a password on a tty) and `ksh` (not installed here), both
+        valid spellings; and `xargs -I {} cp {} dst`, which with no stdin exits 0
+        having copied nothing. That last one is deliberate and stays — what this
+        table probes is whether the DETECTOR sees the writer, and the detector
+        reads words, not behaviour. An earlier version of this docstring said
+        "each spelling", which was false for three of seventeen.
         """
         self.assertEqual(
             set(self._WHOLE_FRAGMENT_HEAD_SPELLINGS),


### PR DESCRIPTION
Records what PR #98's five-round review loop cost, in the skill that ran it. Two commits: the lessons, then one review round on them — which found that three of the first commit's claims were wrong and that the new rule's own summary named the weaker of two checks.

## Three rules, all found BY reviewers in the loop's own instructions

**1. `-x` can make a whole mutation run a false green.** If the `--test-cmd` you pass already has a failure unrelated to the change, `-x` stops every mutant at that same failure and every mutant is recorded `killed`. met-dsl's standing instance is the two path-depth-coupled `ForbidBackendCredentialReadTests` cases, which fail in a `/tmp` worktree and pass in the checkout. `mutation_check.py`'s baseline refuses this (red baseline, exit 2); a handwritten sweep does not, and one reviewer reported 12 of 12 mutants killed that way before re-running. Folded into the existing PR #67 "run the baseline for handwritten sweeps too" bullet — same false green, second cause — and added to the script's own docstring, which still said "pass `-x`" unqualified.

**2. "Delete the test and see it fail" cannot be followed literally.** That is the sonnet axis's back-check for a "pinned by Y" claim, and removing a passing `unittest` method usually cannot turn another one red. A reviewer said so rather than quietly reinterpreting it — the most useful thing that axis has done. It now says to delete what the test is ABOUT. Not an absolute, though: the review round found two rows here that DO notice a deleted sibling (`AgentRoleFailClosedTests::test_this_class_census_is_accurate` compares an in-class census against `dir(type(self))`; `SkillReachabilityTests._run_row` constructs a test by name), and both are named.

**3. A probe family generated from a constant can be chosen from the corner where it cannot fail.** The costliest, because it counterfeits the good practice it looks like. Generating one probe per member IS set identity — a member added without a probe gets one — but the generated SPELLING can be the one shape every member survives. PR #98 shipped three, one per round, each written into a commit message as having settled the question: 48 spellings that were all long options for a branch that could only differ on a short one; 8 fd-dup spellings all written with a space before the fd digit, for a pass whose whole question is the glued form; and 8 wrappers probed as `f"{name} cp a b"`, in the set-identity test itself, where `timeout cp a b` is not an invocation `timeout` accepts at all.

## What the review round changed about rule 3

A reviewer applied it to 13 table-driven families in `tools/tests/`: **3 real weaknesses, 2 false alarms, 9 cleared, ~41 minutes.** That sweep rewrote the rule:

- **"The check is one question" was wrong.** On the sharpest hit — a bundle-gate restatement scan generating one quote style where its neighbour loops both — that question CLEARS the test. What finds it is the clause the first draft demoted to a follow-on. Two checks of equal weight now.
- **"the thing under test" was ambiguous, and answering it wrong flips the result.** For a wrapper table the accepting party is bash/`timeout`; for a detector fed arbitrary argv it is the detector; for a source-text scan it is Python's grammar. The rule now says: whatever produces the input in production, which is often not the code under test.
- **A carve-out was missing.** A loop asserting a property every member is SUPPOSED to have (`assertTrue(name.strip())` over a curated constant) is a future-guard, not a measurement — no current member can fail, and that is the point. Without this the rule fires on every such loop; one of the two false alarms was exactly that.
- **The claimed disjointness from the neighbouring "probe contains the implemented value as a substring" sign does not hold.** The reviewer's best find is both at once — `'verdict.json'` is a substring of `'aggregate_verdict.json'` in the same tuple, so a family GENERATED a degenerate member. Read literally it routed to neither sign. Replaced with the composition case, naming both remedies.

The rule was also stated **twice**, in round 0 and in Signs, where every other rule in the file is stated once. Round 0 is a one-line pointer now; Signs keeps it, because its framing — "you measured a family and REPORTED THE CONCLUSION" — is the one that avoids the false alarm.

## Three more rules the loop paid for and had not recorded

- **The measurement-substitution remedy fired and failed.** SKILL.md already said "leave no path where a human transcribes"; PR #98 escalated to it after four hand-typed numbers came out wrong, and the very next commit shipped **eight unsubstituted placeholder tokens in its message, directly under the sentence saying the numbers were no longer typed**. The rule now ends with: verify the substitution RAN, with one `re.search`, because this failure looks exactly like success.
- **Your own RESIDUE list rots like a census conclusion.** PR #98's omitted its largest member for two rounds and asserted the interpreter route was covered for three; round 5 established that route was the widest gap on the branch. `docs/RUNBOOK.md` points an operator at that list, which makes it a completeness claim. Re-verify each entry every round, in both directions.
- **When a change ADDS A REFUSAL, read the neighbouring guards' remedy texts.** A sibling's remedy can steer the refused party straight onto the route you did not close: `forbid_python_inline_write` says "use a real script file (`python3 script.py`)", over an allow-list entry that permits exactly that and a leaf-read document that teaches it. Three sources agreeing on a route none of them guards is not something a single-file review sees.

## `references/`

`class-descent-log.md` gains PR #98: the second recorded instance of L128's "ask a weaker question", and the first applied INSIDE a running loop. Three rounds of one-shaped defects said the question — *which operand does this `cp` write?* — could not be answered without re-implementing bash's word splitting plus each tool's getopt grammar; replacing it with *is a file-writing command run here?* closed the family structurally and flipped the failure direction from open to closed. Two things the entry records that L128 does not: **the redesign was put to the user rather than taken**, per the shape-change rule; and **a weaker question buys no smaller review surface** — the replacement drew two more rounds of serious findings, one a fail-open regression against `origin/main`. The class never descended across five rounds and the loop closed at the cap, disclosed as not converged.

`mutation-testing.md` gains the three probe families and how each was closed, the `-x` false green, a revert that reintroduces a SHADOWED duplicate (both halves present in the mutant, so the survivor is real and reads as noise), and the helper-vs-handler pin that four review rounds walked past and a mutation check caught.

## The review round's own findings on this diff

Because they are the reason to trust the second commit more than the first:

- **The citation-coupling evidence I cited was a harness artifact.** The first commit said mutating a `references/` citation takes `test_skill_citations.py` "from 34 passed to 32 failed in a `git archive` copy". That test reads from `git ls-files` / `git show :<path>`, so a `git archive` copy — no `.git` — gives 32 failed with **no mutation at all**. The measurement could not have come out the other way, in the commit that exists to record that defect class. Measured properly, in a worktree with the change staged: **2 failed, 32 passed**.
- **"17 wrappers" was 8** — 17 is the size of the table that REPLACED the broken one, and the same paragraph said "six of eight were defeated".
- **"`timeout cp a b` is not valid bash"** is wrong about which party refuses it: `bash -n` exits 0, `timeout(1)` answers `invalid time interval 'cp'`, rc=125.
- **A false claim in the merged PR #98 code**, corrected here: `test_every_whole_fragment_head_is_scanned`'s docstring says all 17 spellings were confirmed under bash to perform the copy. It is 14 — `sudo` wants a tty password on this host, `ksh` is not installed, and `xargs -I {} cp {} dst` with no stdin exits 0 having copied nothing (rc=0, only the source file present).

## Verification

- `env -u METDSL_ORCHESTRATION_ID -u METDSL_CHILD_AGENT_RUN_ID -u METDSL_WORKFLOW_MODE python3 -m pytest tools/tests/ -q`: **5225 passed**, unchanged from `9b4956e`.
- `tools/tests/test_skill_citations.py`: 34 passed. Every `references/` path the diff cites is mechanically coupled — mutating one to a non-existent file gives 2 failed, 32 passed (worktree, staged).
- `mutation_check.py` on the first commit: 8 hunks, 8 survived, which is the expected result for a documentation diff and is itself the measurement. Split as the skill requires: the citations are checked, the `timeout` behaviour was RUN rather than checked (a test shelling out to `timeout` would couple the suite to the tool being installed), and the rest is declared prose.
- SKILL.md 51818 → 57611 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJxKAr4duZpY3TDzkNhRqV
