### PR TITLE
Four review-loop lessons PR #100 paid for, and the episode behind each

### DIFF
--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -144,7 +144,11 @@ when a rule does not obviously apply:
   as a survivor (PR #86, visible only because the harness printed `PATCH DID NOT APPLY` instead
   of counting them green), and a not-applied patch is a failed run, not a finding. **The script is
   not universal either: one hunk can bundle a pinned and an unpinned change, so follow up at line
-  granularity when one rule lives in N places**
+  granularity when one rule lives in N places**. **A handwritten sweep over a SINGLE file must run
+  with `PYTHONDONTWRITEBYTECODE=1` and `-p no:cacheprovider`** — consecutive same-byte-length
+  rewrites within one second reuse a stale `.pyc`, and the mutant that reports `killed` is the
+  PREVIOUS one. Two reviewers hit it independently on PR #100, one of them reporting three live
+  mutants as killed; the skill's own script is unaffected because each hunk gets its own worktree
 - **Never revert a mutation with `git checkout -- <file>`; it deletes uncommitted work too.** Use
   a worktree (the script's default; `--keep` leaves it REGISTERED, and `git worktree prune` will NOT
   unregister one whose directory still exists — `git worktree remove <path>` does) or a `cp` backup
@@ -207,6 +211,16 @@ when a rule does not obviously apply:
      sentence saying the numbers were no longer typed (an f-string ate the doubled braces). Assert
      that no placeholder survives before you commit — one `re.search` — because a message cannot be
      fixed after it is pushed, and this failure looks exactly like success
+   - **Before you DERIVE a threshold from a measurement, enumerate the comparable runs you already
+     have.** Generating a number from the artifact stops transcription errors and does nothing
+     about this one: on PR #100 a requirement inferred from one closure was falsified by the NEXT
+     DAY's closure — same node, same endpoint, same models, running the very configuration the
+     document recommended, and sitting in the same `workspace/` the measurement came from. Three
+     rounds of reviewers re-derived the number correctly because they, too, were handed the one
+     run. **A derived threshold needs its POPULATION stated** ("largest completed draw across the
+     N runs that have one"), and the sweep that finds the population is one loop over the corpus,
+     not a judgment call. Where the population is one, say so and call the number a bound rather
+     than a requirement
 
    Episodes: `references/measurement-records.md`.
 
@@ -506,6 +520,14 @@ cut, and it runs both ways:
   on the "false evidence" side
 - **rough edges in existing behaviour this PR does not touch** — file them in TODO.md and hand
   them over. Pulling them in compounds "fixes calling for fixes"
+- **the SIBLING file a reviewer noticed has the same gap** — when the gap is structural but your
+  EVIDENCE does not reach it, the gap is the honest thing to leave. PR #100 took a reviewer's
+  "this other sample omits the same field" and wrote the rule into a second provider's sample on
+  the strength of the omission being identical; the guidance was not, and the next round found a
+  wrong field name, the rule's own censoring principle inverted, and a warning about a code path
+  that cannot execute. The whole edit was reverted. **The test is not "is the gap the same" but
+  "does my measurement cover the sibling"** — if it does not, say in the PR that the gap is
+  deliberate and belongs to whoever measures it
 
 **When the change ADDS A REFUSAL, read the remedy texts of the neighbouring guards.** A sibling's
 remedy can steer the refused party straight onto the route you did not close, and then the hole is
@@ -693,7 +715,22 @@ that tells you how it closed.
   (`.claude/skills/metdsl-enforcement-change/references/verification.md`). **Rewriting one
   statement repeatedly is a SWEEP problem, which this row owns; several sites that each state the
   rule is a COUPLING problem, which `metdsl-enforcement-change` rule 3-a owns and states the
-  threshold for.** Do not restate its number here — that is the drift this pair is about
+  threshold for.** Do not restate its number here — that is the drift this pair is about.
+  **A sweep does not help when the sentence SUMMARISES a measurement** — "at the top of the band",
+  "above every rate observed" — because there is one site and it is wrong on its own terms. PR #100
+  got that sentence wrong in three consecutive rounds, each version written to fix the previous
+  one. What closed it was DELETING the summary: state the figures, state what they are being
+  compared against, and leave the comparison to the reader. A summary of a spread is a claim with
+  no witness; the spread itself has one
+- **A term you coined for a tool has appeared in a document as if the system used it** → check it
+  against the vocabulary the repository already defines. On PR #100 a reporting script labelled any
+  body it could not parse "body is not an event stream", and that phrase was then written into
+  `docs/ORCHESTRATION.md` as the run's own classification — where
+  `response_not_an_event_stream` is a DIFFERENT thing that fails closed on the first attempt, so
+  the document had one leaf both spending a retry budget and belonging to a class that cannot. **A
+  new term needs one `grep` against the canonical documents before it ships**, and a tool whose
+  output will be transcribed should say what it OBSERVED ("no frames parsed") rather than what it
+  concluded
 - **Prose that enumerates entities in the code** (test names, call-site counts, numbers of
   readers) → **re-measuring loses. Turn it into a check.** Criterion: should this prose break if
   one test is renamed? Then make it a check (the general form, and when a check is the wrong

--- a/.claude/skills/metdsl-review-loop/references/class-descent-log.md
+++ b/.claude/skills/metdsl-review-loop/references/class-descent-log.md
@@ -282,6 +282,43 @@ measured as lost, and nothing pins the total** — the reachability check pins t
 reachable, not that the entry point stays small. A reader who needs today's figure runs the
 command.
 
+## PR #100 — four rounds, no descent, closed by changing the question twice
+
+A documentation change (land a sizing rule out of a gitignored operator config) that grew a
+committed instrument and its tests. Twelve subagent reviews over four rounds, no Codex pass (a
+prose-centred diff, per SKILL.md's "cases where not launching is better").
+
+**The class never descended.** Every round produced FALSE EVIDENCE findings, and in every round the
+worst of them sat inside the previous round's fix:
+
+| Round | What the previous fix had introduced |
+|---|---|
+| 1 | a hand-transcribed reasoning value that does not exist in the run it cites |
+| 2 | a boldface provenance claim false for three figure groups, withdrawn by its own paragraph 4 000 characters later; and "elapsed cannot be re-taken", which was false and suppressed a re-takeable measurement |
+| 3 | the rule exported to a second provider's sample it was never measured on — wrong field name, the censoring rule inverted, a warning about an unreachable code path. Reverted whole |
+| 4 | a requirement inferred from one closure, falsified by the next day's closure in the same workspace; and the instrument's own vocabulary written into the document as the system's classification |
+
+**What ended it was not a round, it was two shape changes**, both in round 4 and both instances of
+"change to a weaker question that can be answered":
+
+- the document stopped stating an inferred requirement and started stating the largest COMPLETED
+  draw across a named population, as a bound that moves;
+- the sample config stopped summarising a spread of rates in prose — a sentence that had been wrong
+  in three consecutive rounds, each version written to fix the last — and stated the figures
+  instead.
+
+**Two readings for the next loop.** First, the recurrence signal fired correctly and I was slow to
+act on it: SKILL.md says three rounds of the same mechanism means the question is wrong, and this
+loop ran four. Second, the strongest finding of the branch came from the blank-slate reviewer the
+budget mandates from round four, on a branch where rounds 1-3 had all inherited the same evidence
+base — which is an argument for spending one no-history slot EARLIER than round four when the
+evidence is a fixed artifact everyone is handed.
+
+Stopped at the budget with the branch merged and the conditions disclosed in the PR body: class
+descent not achieved, blank-slate zero-functional-defects not achieved twice. The instrument's
+census is explicitly not closed — an independent census found 24 of 40 mutants surviving in round
+4, and the author's own 12-mutant sweep afterwards is a statement about those 12.
+
 ## Census practical notes: the episode behind each (restored 2026-08-25)
 
 These six were compressed to one line each in `SKILL.md` §"Stopping conditions" and their

--- a/.claude/skills/metdsl-review-loop/references/measurement-records.md
+++ b/.claude/skills/metdsl-review-loop/references/measurement-records.md
@@ -29,3 +29,35 @@ this file keeps the episodes that produced them.
      `-U5` gave 21 / 17 / 15 on one range). Name the width, the command, and the exclusions.
    - **Recording that a number "was right when written" does not stop the next rot** — that
      sentence itself was written twice and rotted twice. Only changing the form stopped it.
+
+## PR #100 — a generated number, falsified by a run nobody opened
+
+The branch that produced `SKILL.md`'s "enumerate the comparable runs" rule did everything the four
+rules above ask. The figures were produced by a committed instrument rather than typed, the
+document named the run they came from, and three rounds of reviewers re-derived every one of them
+independently and found no arithmetic wrong.
+
+Round 4 pointed the same instrument at a DIFFERENT run. `orch_20260807T002410Z_acf2b996` — the next
+day's closure of the same node, the same endpoint, the same two models, running the very
+configuration the document recommended, and PASSING — drew 82 210 output tokens where the document
+had inferred a requirement of 72 674-74 302 from the previous closure. It had been on disk in the
+same `workspace/` the whole time.
+
+Three things this episode establishes that generating-from-the-artifact does not cover:
+
+- **The rot was not in the number, it was in the QUANTIFIER.** "The requirement is 72 674-74 302"
+  was arithmetic over the one closure that had been opened; nothing in it was mistyped, and no
+  re-measurement of that closure would ever have caught it.
+- **Every reviewer inherited the population.** Rounds 1-3 were handed the same single run and
+  checked the arithmetic over it, correctly, three times. A reviewer instruction to "re-take the
+  measurement" reproduces the sample; only "find the comparable runs" changes it. The finding came
+  from a blank-slate reviewer with no history, which is the round the budget places at four.
+- **The fix was to change the question, not the number.** Patching 72 674-74 302 to 82 210 would
+  have invited the next closure to falsify that. The document now states the largest COMPLETED
+  draw across the runs available, names the population (two closures, 11 leaf requests), and calls
+  it a bound that moves. That form cannot be falsified by a new run — it is updated by one.
+
+The corpus sweep that would have caught it is one loop: every `workspace*/orchestrations/orch_*`
+with a `launches/*.http_response.txt`, run through the instrument. It found two runs, and took
+under a minute.
+

--- a/.claude/skills/metdsl-review-loop/references/mutation-testing.md
+++ b/.claude/skills/metdsl-review-loop/references/mutation-testing.md
@@ -342,3 +342,32 @@ and the suite stayed green. SKILL.md already names the shape ("Pin at the handle
 what this episode adds is that a MUTATION CHECK is what surfaced it, after four review rounds had
 not, and that the tell is a survivor on a one-line call-site hunk.
 
+### A stale `.pyc` reports the PREVIOUS mutant's verdict (PR #100)
+
+Two reviewers, independently, hit this while sweeping a single committed script by rewriting it in
+place. Successive mutants of one file are often the SAME BYTE LENGTH, and if two of them are written
+within the same second, CPython's source-mtime check cannot tell them apart and reuses the cached
+bytecode. One reviewer's first sweep reported three live mutants as killed; the verdict printed was
+the previous mutant's. Both re-ran with `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest ...
+-p no:cacheprovider` and the three came back SURVIVED.
+
+`mutation_check.py` is unaffected — each hunk gets its own worktree, so no two mutants share a path
+— which is exactly why the trap is invisible until you write a sweep by hand, and why the flags now
+appear in SKILL.md's handwritten-harness rule. The general form is the one already in this file: a
+handwritten harness fails in ways the script has designed out, and the failures all look like
+green.
+
+### The fixture built from the constant under test (PR #100)
+
+A witness census had found the script's `WORKSPACE_ROOT` unpinned, so a test was written for it —
+and the mutant pointing the constant at `workspace/NOPE` still passed. The test had built its
+fixture directory with `root / leaf_token_report.WORKSPACE_ROOT / "orch_xyz"`, i.e. from the
+constant it was checking, so it asserted the constant equals itself. Spelling the layout literally
+(`root / "workspace" / "orchestrations"`) killed the mutant.
+
+This is the "generating the probes FROM a constant gives set identity" sign, in its simplest
+possible form and inside a test written specifically to close a census finding. **The tell is that
+the fixture imports the module under test to build the expected value.** Check (a) from SKILL.md
+applies unchanged: name an input for which this test could fail. If the answer requires the
+constant to be self-inconsistent, it cannot fail.
+


### PR DESCRIPTION
Lessons from the review loop on #100, split the way this skill asks: rules in `SKILL.md`, the episode behind each in `references/`.

#100 ran four rounds without the severity class descending, and closed by changing the shape of two claims rather than patching them. Four of the things it cost were not already in the skill.

## Rules (`SKILL.md`, +41 lines)

- **Round 0 item 2 — "before you DERIVE a threshold, enumerate the comparable runs you already have."** The four rules there are about a number rotting or being mistyped. This one is about the quantifier. #100 generated its figures from a committed instrument, named the run, and had three rounds of reviewers re-derive them correctly — and the number was still false, because it was arithmetic over the one closure anyone had opened. The next day's closure, already on disk in the same `workspace/`, exceeded it. A derived threshold needs its population stated; where the population is one, it is a bound, not a requirement.
- **The handwritten-harness rule gains `PYTHONDONTWRITEBYTECODE=1` / `-p no:cacheprovider`.** Sweeping one file in place, successive mutants are often the same byte length, and two written within a second share a cached `.pyc` — the verdict printed belongs to the *previous* mutant. Two reviewers hit it independently. `mutation_check.py` is immune (a worktree per hunk), which is exactly why it is invisible until you write a sweep by hand.
- **"Rewritten the same string three times" gains its non-sweep case.** A sentence that *summarises* a measurement has one site, so the sweep the row prescribes finds nothing. #100 got one such sentence wrong in three consecutive rounds, each version written to fix the last. Deleting the summary closed it.
- **A new sign: a term coined for a tool, appearing in a document as the system's own classification.** A reporting script labelled anything it could not parse "body is not an event stream"; that reached `docs/ORCHESTRATION.md` as the run's verdict, where `response_not_an_event_stream` is a different class that fails closed on the first attempt — leaving one leaf both spending a retry budget and belonging to a class that cannot.
- **"Fix or out of scope" gains the sibling-file row.** A reviewer noticed a second sample config with the same omission. The omission was structurally identical; the guidance was not. Writing it there produced a wrong field name, the censoring rule inverted, and a warning about an unreachable code path, and was reverted whole. The test is not whether the gap is the same but whether your measurement reaches the sibling.

## Episodes (`references/`, +98 lines)

`measurement-records.md` carries the falsified-requirement episode, including the part that generalises: every reviewer inherited the population, so three rounds re-derived the same sample correctly. `mutation-testing.md` carries the stale-`.pyc` sweep and a fixture that built its directory layout from the constant it was testing — the "set identity" sign in its simplest form, inside a test written specifically to close a census finding. `class-descent-log.md` carries #100's round-by-round history.

That last entry records two readings that are unflattering to how I ran the loop, because they are the actionable ones:

- **The recurrence signal fired at three rounds and I acted at four.** `SKILL.md` already says three rounds of the same mechanism means the question is wrong.
- **A no-history reviewer is worth spending earlier than round four** when the evidence is a fixed artifact every reviewer is handed. Rounds 1-3 all inherited the same single run; the branch's strongest finding came from the blank-slate slot the budget places at four.

## Verification

Full suite at `e364906`: 5250 passed. Skill/doc-facing subset (`-k "skill or doc or citation"`): 164 passed. Documentation only — no `tools/`, `mcp_servers/` or `skills/` (workflow) change, and nothing here reaches a workflow leaf: this is the dev-layer `.claude/skills/` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
