### PR TITLE
Record what PR #104 taught the two review skills

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/SKILL.md
+++ b/.claude/skills/metdsl-enforcement-change/SKILL.md
@@ -281,6 +281,15 @@ one.**
 - **There is one way to find this. Do not poke the validator in a unit test; drive the production
   entry point end to end and assert on the final product** (the rendered prompt, the persisted
   JSON)
+- **A SYNTHETIC input measures nothing for a value the production code resolves from somewhere
+  else.** Before building a fixture around an input, find out where the code under test actually
+  reads that value from. Two instances on PR #104, both of which produced a test that passed while
+  observing nothing: a witness drove the Bash guard with a synthetic `repo_root` in the payload,
+  but `~+` is `$PWD` and `tools/hooks/common.py` expands it from `os.getcwd()`, so the anchor
+  pointed at wherever pytest was started; and a spy's frame walk anchored on `os.getcwd()` was
+  handed probe modules written into a `tempfile` directory, so it missed on every self-test and
+  fell back silently. **The fix in both cases was to move the process, or to make the root an
+  argument** — not to make the fixture more elaborate
 
 ### 3. Decide the failure's attribution
 

--- a/.claude/skills/metdsl-enforcement-change/references/verification.md
+++ b/.claude/skills/metdsl-enforcement-change/references/verification.md
@@ -381,6 +381,39 @@ something else moves the count, so the ratchet fails and the mutant reads as kil
 that has nothing to do with behaviour. On TODO:269 that hid an exit-code mapping with no
 behavioural witness at all. When a mutant dies, read WHICH row died.
 
+## A CPU-time budget is still a machine fact
+
+Reach for this whenever a check asserts that something is FAST. Wall clock is obviously
+load-dependent; **`time.process_time()` is not the fix, and believing it is has a measured cost**.
+On PR #104, the same two hook blocks cost 1.13-1.21s of CPU solo, 1.40-1.48s under three
+concurrent pytest runs and 2.30-2.41s under 44 spinners on a 22-core host — 2.1-2.5x of movement
+against a 5.0s bound, and a reviewer independently measured one of them at 12.21s. CPU time
+inflates under contention because the work itself costs more cycles (cache and memory pressure,
+and WSL2 scheduling), so there is no absolute number that is safe.
+
+What the branch shipped, and what it is worth:
+
+- **A bound RELATIVE to a calibration workload measured in the same process, around the block.**
+  Across load levels this helps: seconds moved 5.5x while the quotient moved 2.1x in one
+  measurement, 5.0x and 3.0x in an independent one. **Within one load level it costs**, because a
+  ~0.1s denominator does not average out the way a 1-10s numerator does — a reviewer's heavy batch
+  moved 1.36x in seconds and 2.36x in units. **More samples do not fix that**: mean-of-2,
+  median-of-5 and median-of-9 estimators all spread 1.8-2.0x across fresh processes, quiet and
+  loaded alike, because what moves is the host between one process and the next.
+- **So do not justify the bound by the compensation.** Justify it by a BRACKET with both ends
+  measured: above every figure ever observed for that block, and below the smallest regression the
+  check has ever caught. State both figures. The first version of that comment argued a mechanism
+  ("1.4x of spread instead of 2.5x"), a reviewer refuted it in fresh processes, and what survived
+  review was deleting the argument and keeping the numbers.
+- **The calibrator needs its own witness, and an implausible constant is not enough.** `return 1.0`
+  was killed by the self-test; `elapsed = 0.05` — the number the calibrator usually returns on that
+  host — passed every bracket and silently turned the quotient back into raw seconds. Pin that the
+  price RESPONDS: quadruple the workload and require the measurement to follow.
+- **The failure message must say what a unit is and what to do.** A bare "21.9 calibration units"
+  names something defined only in the file the reader is not looking at. And do not put a claim
+  about the bound's derivation in a shared `describe()` — on that branch the sentence was true of
+  two of ten call sites, including two LOWER bounds where it was exactly backwards.
+
 ## Mutation check
 
 Use `.claude/skills/metdsl-review-loop/scripts/mutation_check.py`. The procedure is owned by

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -104,7 +104,10 @@ when a rule does not obviously apply:
   instructions too
 - **Run the baseline for handwritten sweeps too, and read it before you trust `-x`** — the script
   refuses a red baseline (exit 2); a sweep you write yourself will not. Two causes, same false
-  green: a stale worktree (PR #67), and a suite that ALREADY has a failure unrelated to the change,
+  green: a stale worktree (PR #67), a sweep KILLED mid-run — a timeout or a Ctrl-C skips the
+  `finally` that restores the file, so the NEXT run measures a mutated baseline (PR #104; the
+  script caught it and exited 2, which is the behaviour to keep) — and a suite that ALREADY has a
+  failure unrelated to the change,
   where `-x` stops every mutant at that same failure so every mutant reads as `killed` — a false
   green over the whole run, not a per-hunk slip. met-dsl's standing instance is the two
   path-depth-coupled `ForbidBackendCredentialReadTests` cases, which fail in a worktree under
@@ -140,18 +143,26 @@ when a rule does not obviously apply:
   mutants that kill each decision of the new machinery one at a time
 - **Do not handwrite a mutation harness** (PR #53's `str.replace` rewrote all occurrences at
   once, hiding 2 reachable fail-opens). If you must: hit occurrences one at a time, **assert the
-  patch applied**, and **re-point a mutant list reused across rounds** — a stale target reports
-  as a survivor (PR #86, visible only because the harness printed `PATCH DID NOT APPLY` instead
-  of counting them green), and a not-applied patch is a failed run, not a finding. **The script is
+  patch applied AND that it changed behaviour**, and **re-point a mutant list reused across
+  rounds** — a stale target reports as a survivor (PR #86, visible only because the harness
+  printed `PATCH DID NOT APPLY` instead of counting them green), and a not-applied patch is a
+  failed run, not a finding — **report it as its own category and count it out of the denominator**.
+  "Applied" is not enough on its own; a semantically identical rewrite patches cleanly and proves
+  nothing. **And do not PATCH a mutant list between rounds — write it out**, and **read the RUN's
+  own output, not only the artifact it produces** (PR #104: three silent misses, two of them
+  reporting plausible totals for a sweep that measured nothing new). **The script is
   not universal either: one hunk can bundle a pinned and an unpinned change, so follow up at line
   granularity when one rule lives in N places**. **A handwritten sweep over a SINGLE file must run
   with `PYTHONDONTWRITEBYTECODE=1` and `-p no:cacheprovider`** — consecutive same-byte-length
   rewrites within one second reuse a stale `.pyc`, and the mutant that reports `killed` is the
   PREVIOUS one. Two reviewers hit it independently on PR #100, one of them reporting three live
   mutants as killed; the skill's own script is unaffected because each hunk gets its own worktree
-- **Never revert a mutation with `git checkout -- <file>`; it deletes uncommitted work too.** Use
-  a worktree (the script's default; `--keep` leaves it REGISTERED, and `git worktree prune` will NOT
-  unregister one whose directory still exists — `git worktree remove <path>` does) or a `cp` backup
+- **Never revert a mutation with `git checkout -- <file>`. TWO reasons, and the second is worse:
+  it deletes uncommitted work, and on an UNTRACKED file it is a SILENT NO-OP** — PR #104 shipped a
+  mutant for two commits that way. Use a worktree (the script's default; `--keep` leaves it
+  REGISTERED, and `git worktree prune` will NOT unregister one whose directory still exists —
+  `git worktree remove <path>` does) or a `cp` backup, and **never `cp` out of a worktree you have
+  been mutating without checking it is clean first**
 - **Mutation checking cannot detect a test spinning in neutral.** A live-but-unobserved hunk
   looks like a pass (L128: deleting the scope mechanism outright kept everything green and all 5
   tests meant to pin it were inert). Countermeasures — each with its episode in the reference:
@@ -173,6 +184,12 @@ when a rule does not obviously apply:
     the relationship in the fixture, not to unset the variable
   - **a mechanism that guards the HARNESS cannot be witnessed from inside the suite** — put the
     witness in a subprocess outside the runner
+  - **a rule whose answer on THIS tree is "nothing" cannot be observed through the assertion that
+    consumes it.** `assertEqual(rule(corpus), set())` is green whether the rule computes the right
+    empty set or returns one unconditionally, and mutating it mutates an assertion, which survives
+    by construction. **Move the rule into a module and drive it on synthetic input where the answer
+    is not nothing** — both directions, because for a rule that REFUSES something the over-refusing
+    direction is the one you will get wrong (PR #104, three mechanisms, same fix)
   - **when a comment JUSTIFIES a rule, mutate the property the justification names** — the rule
     has a witness, the property holding it up usually does not
   - **kill enumerations one element at a time** (regex alternatives, keyword tables); checked
@@ -203,6 +220,16 @@ when a rule does not obviously apply:
      pinned") — that is what the reader needs and what survives when the number is obsolete
    - **A count with no unit is not reproducible** — "14 hunks" came back as 19 and 16 because the
      figure depends on the diff CONTEXT WIDTH. Name the width, the command, and the exclusions
+   - **Name WHERE a suite figure was measured.** A number can be right and still be a defect if it
+     does not say which checkout produced it: met-dsl's suite is one lower in a `/tmp` worktree
+     than in the primary checkout, because a declared skip fires there. On PR #104 a reviewer
+     correctly reported a commit message as wrong for that reason, and the message was right —
+     it simply had not said where
+   - **A count that no method can reproduce is worse than no count.** PR #104 quoted five figures
+     for "the names this tree reads"; the two that named their reader re-derived exactly, and three
+     named no spelling, no file set and no reader — so the sentence claiming each answered a
+     different question could not be checked. **Either write the command beside the number, or
+     write the property instead and check it**
    - **Recording that a number "was right when written" does not stop the next rot.** Only
      changing the form stopped it
    - **And then verify the substitution RAN.** The remedy has its own failure mode: PR #98 escalated

--- a/.claude/skills/metdsl-review-loop/references/mutation-testing.md
+++ b/.claude/skills/metdsl-review-loop/references/mutation-testing.md
@@ -371,3 +371,60 @@ the fixture imports the module under test to build the expected value.** Check (
 applies unchanged: name an input for which this test could fail. If the answer requires the
 constant to be self-inconsistent, it cannot fail.
 
+## Additions from PR #104 (issue #84, 2026-08-27)
+
+### A mutant survived a "revert" and shipped for two commits
+
+The file was UNTRACKED in the worktree where the mutation was applied, so
+`git checkout -- <path>` exited 0 and did nothing, and the `|| true` beside it swallowed even
+that signal. A later `cp` of that worktree's files into the checkout carried the mutant in, where
+it was committed and survived a whole-suite run, a poisoned whole-suite run and a 24-mutant sweep.
+
+Three things would each have caught it, and the third is the general one:
+
+- the sweep that followed re-applied the same mutation and printed `PATCH-FAIL (count=0)`. **That
+  is the tell, and it was read as an anchor typo.** A patch whose anchor has vanished is either a
+  stale mutant list or a mutation already present.
+- the poisoned run's own witness DID fail, correctly. It was misdiagnosed as a value collision —
+  the poison value happened to equal the value the suite's own `setdefault` uses — and the first
+  fix drafted was an exemption that would have silenced that witness permanently. **When a test
+  fails, read WHY before deciding it is the test's fault.**
+- what closed it structurally: the function now verifies its own postcondition (`pop` the name,
+  then raise if it is still present) so the shape cannot be present and quiet whatever carries it
+  in. **Discipline lost twice here; a postcondition does not.**
+
+### The sweep list is not a place to patch
+
+Three consecutive attempts to insert new mutants into an existing list by string anchor missed
+silently. Two of them reported plausible totals — 32 mutants, 28 killed — for a sweep that
+contained none of the round's new mechanisms. The third had an `assert`, which fired into a
+background log that was not read while the artifact log was. **Write the list out explicitly, and
+read the run's own output rather than only the file it produces.**
+
+### A killed sweep leaves its mutation behind
+
+A sweep stopped by a timeout skips the `finally` that restores the file. The next run then
+measures a mutated baseline. The script's `exit 2` on a red baseline is what turns that into a
+visible stop instead of a plausible-looking result on a dirty tree — keep it, and re-create the
+worktree rather than debugging the baseline.
+
+### A rule whose answer is "nothing" cannot be witnessed through its own assertion
+
+Three mechanisms on this branch survived a sweep for the same reason: each was an expression
+inside the test that consumed it, and on this tree each evaluates to the empty set. Neutering
+them changed nothing observable, because mutating an expression inside an assertion is mutating
+the assertion. Each was closed the same way — move the rule into a module beside the tables it
+asks about, and drive it on synthetic input where the answer is not nothing, in BOTH directions.
+For a rule that refuses something, the over-refusing direction is the one that was wrong: the
+import-capture rule refused every import-time read, including `HOME`, which the guard never
+strips, with a message telling the reader to declare it where it already was.
+
+### A neighbouring mechanism can hide a missing restore
+
+`isolated_record()`'s witness asserted the record was back after the block. Adding a second
+`isolated_record()` later in the same test made dropping the restore invisible: the later
+`__enter__` clears the record, so it wiped the residue the closing assertion would have seen, and
+a mutant killed since two rounds earlier came back green. **An outer state of "empty" cannot be
+told from a missing restore** — write a sentinel into it first. The same shape had already been
+paid for once in that test, for the flag half, and was reintroduced for the record half.
+


### PR DESCRIPTION
Follow-up to #104. Six rules, each from a defect that cost a round on that branch. Rules in
`SKILL.md`, episodes in `references/`, per those files' own split — an earlier draft had the
episodes in both, which is the defect class these skills exist to kill.

Documents only; no code, no tests. Suite 5304 passed.

## `metdsl-review-loop/SKILL.md`

- **`git checkout -- <file>` gains its second and worse reason: on an UNTRACKED file it is a
  silent no-op.** The existing ban named only "it deletes uncommitted work". The larger cost was
  the other one — a reviewer's mutant survived that "revert" in a worktree, was carried into the
  checkout by a later `cp`, and **shipped for two commits**, through a whole-suite run, a poisoned
  run and a 24-mutant sweep.
- **A mutant must be asserted to have applied AND to have changed behaviour**; a `PATCH-FAIL` is
  its own category, counted out of the denominator; **a mutant list is written out, not patched
  between rounds**; and **read the run's own output, not only the artifact it writes**. Three
  consecutive anchor-based insertions missed silently on #104, two of them reporting plausible
  totals for a sweep that contained none of that round's new mechanisms.
- **A third cause of a red baseline**: a sweep killed mid-run skips the `finally` that restores the
  file, so the next run measures a mutated tree. The script's `exit 2` is what makes that a visible
  stop instead of a plausible-looking result.
- **A new countermeasure for tests spinning in neutral**: a rule whose answer on this tree is
  "nothing" cannot be observed through the assertion that consumes it. Move it into a module and
  drive it synthetically, in **both** directions — three mechanisms on #104 survived a sweep for
  exactly this reason, and for a rule that REFUSES something the over-refusing direction is the one
  that was wrong.
- **Two measurement-record rules**: name WHERE a suite figure was measured (a number can be right
  and still be a defect — this repository's total is one lower in a `/tmp` worktree, and a reviewer
  correctly reported a correct commit message as wrong for that reason), and a count no method can
  reproduce is worse than no count.

## `metdsl-enforcement-change/SKILL.md`

- **A synthetic input measures nothing for a value the production code resolves from somewhere
  else.** Two instances on #104, both producing a test that passed while observing nothing: a Bash
  guard driven with a synthetic `repo_root` when `~+` is `$PWD` and is expanded from
  `os.getcwd()`; and a frame walk anchored on the cwd while its probe modules were written into a
  `tempfile` directory, so it missed on every self-test and fell back silently. The fix in both
  cases was to move the process or make the root an argument, not to elaborate the fixture.

## `references/verification.md`

New section on CPU-time budgets. **`time.process_time()` is not the fix for a wall-clock flake**
and believing it is has a measured cost: the same blocks moved 2.1-2.5x across load levels against
a 5.0s bound, and a reviewer measured one at 12.21s. A calibrated quotient helps ACROSS load levels
and costs WITHIN one, and more samples do not fix that — mean-of-2, median-of-5 and median-of-9
estimators all spread 1.8-2.0x. So justify such a bound by a bracket with both ends measured rather
than by the compensation, and **give the calibrator a witness that a PLAUSIBLE constant fails**: on
#104 `return 1.0` was killed while `elapsed = 0.05`, the number the calibrator usually returns,
passed every bracket and silently turned the quotient back into raw seconds.

## What I deliberately did not add

The **rate** itself. On #104 every round without exception found a real defect in the previous
round's fix, so the "review the previous round's fixes" axis hit 100%. Promoting that to "always
run that axis" or to a stopping condition would be written from a population of one, and the
alternative reading — a high rate means the change's shape is wrong — already exists as the
five-round class-descent sign. Left for a second data point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)