### PR TITLE
Exclude operator's local Claude transcript data from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,16 @@ plans/
 workspace/
 workspace_*/
 workspace_backup_*/
+
+# The operator's own Claude Code session transcripts, copied from the machine that ran the
+# orchestrations this checkout carries. `skills/workflow-timing-audit/` reads them: a leaf's
+# token record is not written into `workspace*/` at all (no orchestration_meta.json carries a
+# `claude_workflow_home`), so the transcript under the operator's own `~/.claude/projects/`
+# is the only source, and it is machine-local and expires on the CLI's cleanup schedule.
+# Personal working aid, not a canonical record (`AGENTS.md` §Canonical record placement).
+# ANCHORED, like /llm.yaml: this names one directory the operator created at the repository
+# root, and an unanchored pattern would silently ignore a committed transcript_data/ anywhere.
+/transcript_data/
 .serena/
 package-lock.json
 


### PR DESCRIPTION
## Summary
Add `/transcript_data/` to `.gitignore` to exclude the operator's local Claude Code session transcripts from version control. These transcripts are machine-local, temporary artifacts that should not be committed to the repository.

## Changes
- Added `/transcript_data/` to `.gitignore` with comprehensive documentation explaining:
  - Purpose: Operator's own Claude Code session transcripts copied from the machine running orchestrations
  - Why excluded: Machine-local and expires on CLI cleanup schedule; not a canonical record per `AGENTS.md`
  - Implementation detail: Anchored pattern (leading `/`) to match only the repository root directory, preventing silent ignoring of transcripts committed elsewhere in the tree
  - Usage context: Read by `skills/workflow-timing-audit/` for token record analysis

## Implementation Details
The pattern is anchored with a leading `/` (like the existing `/llm.yaml` entry) to ensure it matches only the operator-created directory at the repository root, maintaining consistency with the project's gitignore conventions for repository-root-specific paths.

https://claude.ai/code/session_01Brgnzx3dXMbQMkx1mr32Wo