### PR TITLE
Record what PR #107 taught the two review skills

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/references/verification.md
+++ b/.claude/skills/metdsl-enforcement-change/references/verification.md
@@ -141,6 +141,57 @@ above are for.
 - Measure changes in the fail-closed direction (more refusals) the same way. L128 showed **the
   module dep map for 357 directories byte-identical and 103/103 Makefile verdicts unchanged**
 
+## Extraction diff: what a refactor silently changed (AST, per function)
+
+**A helper extracted from an inline expression is the one change shape where a green suite
+proves nothing**, because both sides are meant to behave identically — so nothing new is
+exercised and nothing old fails. PR #107 shipped one: extracting an ownership predicate out of
+`_cleanup_agent_tmp_root` dropped an `orchestration_id.strip()` that the inline form had, and a
+padded id then resolved to a directory that does not exist, ownership silently failed, cleanup
+refused, and the run kept its tmp scratch. **The whole suite was green on both sides.** It was
+found by diffing the extraction against the text it replaced, and by nothing else.
+
+Read the functions, not the diff. A `git diff` of a refactor is mostly motion, and the one
+changed token sits inside it looking like motion too.
+
+```bash
+git show <base>:tools/orchestration_runtime.py > /tmp/old_rt.py
+git show HEAD:tools/orchestration_runtime.py  > /tmp/new_rt.py
+python3 - <<'EOF'
+import ast, difflib
+def bodies(path):
+    tree = ast.parse(open(path).read())
+    out = {}
+    for n in ast.walk(tree):
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            f = ast.parse(ast.unparse(n)).body[0]
+            if (f.body and isinstance(f.body[0], ast.Expr)
+                    and isinstance(f.body[0].value, ast.Constant)
+                    and isinstance(f.body[0].value.value, str)):
+                f.body = f.body[1:] or [ast.Pass()]      # docstrings are not behaviour
+            out[n.name] = ast.unparse(f)
+    return out
+old, new = bodies("/tmp/old_rt.py"), bodies("/tmp/new_rt.py")
+for name in sorted(set(old) | set(new)):
+    if old.get(name) != new.get(name):
+        print("=== " + name)
+        print("\n".join(difflib.unified_diff(
+            old.get(name, "").splitlines(), new.get(name, "").splitlines(), lineterm="", n=1)))
+EOF
+```
+
+- **`ast.unparse` normalises formatting**, so a reflow, a comment, or a docstring rewrite cannot
+  hide a token. Stripping the docstring is what makes the output short enough to read — on PR
+  #107 it reduced a 1449-line branch diff to **exactly four changed functions**, which is the
+  half that matters: it bounded what else could have been dropped
+- **Run it over the test file too.** Same command, and it answers "which tests changed behaviour"
+  rather than "which lines moved"
+- **This does not replace mutation.** It says what changed; mutation says whether anything
+  notices. An extraction needs both, and needs them in this order: the diff tells you which
+  mutants are worth building
+- **The base is the commit before the refactor**, not `origin/main`, when the branch has several
+  commits — otherwise the refactor's own delta is buried in the feature's
+
 ## ruff shows "identical to the baseline"
 
 Compare per file, not by count. **Add a file to the comparison and the baseline must be retaken**

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -361,6 +361,17 @@ nor resets the two-consecutive-clean-security-rounds condition.**
 
 Episodes for the last three bullets, and the three accidents in full: `references/round-conduct.md`.
 
+**Mid-round mutation is where the round-0 rules actually bite, and they read as if they do not.**
+Everything under "Before you hand it over" is written for the round-0 sweep, but you will mutate
+by hand in every round after it — to reproduce a finding, to check a fix, to see whether a
+reviewer's mutant is real. The two that cost the most are the two easiest to read as round-0-only:
+**never revert with `git checkout -- <file>`** (it deletes uncommitted work, and is a silent
+no-op on an untracked file), and **run the baseline before trusting a green result**. PR #107 hit
+the first in round 2, on the fix commit's own tests — four uncommitted test edits destroyed, redone
+from context, an hour lost — with the rule sitting in this file in those words. `cp` the file to a
+scratch path first and restore from that, or mutate in a worktree; the discipline is the same at
+every point in the loop, not just at round 0.
+
 **Reproduce a finding yourself before classifying it.** Real / false positive / residual /
 **real but out of scope** (below) are decided only with a record of a reproduction you ran. Treat
 "the implementation is right but the test is weak" as real. (`metdsl-enforcement-change` judgment
@@ -373,9 +384,21 @@ ratchet kills this hunk"; a test in another file caught it correctly and was sim
 sweep's gate. **When told "only X caught it", check whether the files holding the other guards
 were inside that reviewer's test command.** If not, it is a report about the measurement scope.
 
+**And verify a reviewer's POSITIVE claims by asking what it EXECUTED.** A "verified true" is
+worth exactly the run behind it, and a reviewer that traces a code path instead of driving it
+will report MATCHES on a claim that is false. PR #107, twice in one round: the mechanical axis
+read `run_gate` top to bottom and confirmed "every refusal invalidates the copy" and "callee
+raises are covered a fortiori" — both false, because two guards sat above the invalidation and
+an ownership guard returned silently, and both were found by the reviewers who RAN the refusals.
+**The tell is a verdict justified by structure** ("X runs before Y, so Y is covered") **rather
+than by an observation** ("I called it with a blank token and the file survived"). Ask for the
+command; a claim that cannot name one is a reading. This is not a reason to distrust the
+axis — the same reviewer refused two false premises I had planted in its own checklist in the
+same run — it is a reason to re-run the positive verdicts your change actually rests on.
+
 ## Delegate verifiable work to sonnet
 
-**Operational conclusion (5 data points; the confound resolved in PR #72 by giving both models
+**Operational conclusion (8 data points; the confound resolved in PR #72 by giving both models
 the same checklist, the axis run as delegated in PR #88): sonnet ⊂ opus, with real misses.** Move **the mechanical-recomputation axis**
 permanently to sonnet and keep judgment on the up-model. Costs came out roughly equal, so "it is
 cheap, so run more" does not hold — **use it only to free up a slot**. Run one via `Agent` with
@@ -403,7 +426,8 @@ arithmetic).
 numbers" does not give "it matches on parser semantics". **Measure per axis.**
 
 **Tell it to report claims it cannot locate rather than accounting for them** — refusing a false
-premise I had put in its prompt is the most valuable thing this axis has done (data point 5).
+premise I had put in its prompt is the most valuable thing this axis has done — and the most
+reproducible, having now happened in three of the eight data points (5, and twice on PR #107).
 **This stays an experiment**: collect real/total findings, elapsed time and the overlap count,
 add a data point each time, and delete this section if it stops paying. How to read overlap, how
 not to confound the comparison, and why the reverse (opus reviewing sonnet's implementation) is

--- a/.claude/skills/metdsl-review-loop/references/sonnet-delegation.md
+++ b/.claude/skills/metdsl-review-loop/references/sonnet-delegation.md
@@ -1,6 +1,39 @@
 # Delegating verifiable review work to sonnet: the experiment log
 
-Five data points. SKILL.md carries the operational conclusion; this is the evidence, newest first.
+Eight data points. SKILL.md carries the operational conclusion; this is the evidence, newest first.
+
+## Data points 6-8 (PR #107, rounds 1, 3 and 4) — three runs, two more premise refusals
+
+Run as the delegated mechanical-recomputation axis in three of the four rounds, in parallel with
+two up-model reviewers each time, same HEAD, checklist-driven.
+
+**Yield.** Round 1: one real finding out of one reported — a document count wrong in a commit
+message and in a test docstring, which the up-model reviewers both missed while disagreeing with
+each other about the number. Round 3: one real MISMATCH out of one reported (a key-order claim
+asserted in a comment with nothing observing it — the shape the branch had criticised an earlier
+round for). Round 4: nothing new; every number matched.
+
+**It refused a false premise in its checklist twice more**, which is now the axis's most
+reproducible behaviour rather than a one-off: in round 1 it reported that the phrase "eight
+surfaces" I asked it to verify appears in none of the commits, and in round 4 that the ceiling /
+headroom claim I asked about is not made by either commit under review. Both times I had written
+the premise myself. **Keep telling it to report what it cannot locate rather than account for it**
+— across four data points that instruction has now returned more value than any single finding.
+
+**Where it is weak, measured.** In round 3 and again in round 4 it returned MATCHES on
+code-path claims that were false, having traced the path rather than driven it: "every refusal
+invalidates the copy" and "callee raises are covered a fortiori" were both confirmed by reading
+and both refuted by the reviewers who ran the refusals. That is not a sonnet-specific failure —
+it is what a reading-based verdict is worth on any model — but the mechanical axis is the one most
+likely to produce one, because its checklist asks for verdicts on many claims cheaply. SKILL.md
+now carries the general rule ("verify a reviewer's POSITIVE claims by asking what it EXECUTED");
+the axis-specific version is: **for a claim about control flow, ask the checklist for the command,
+not the verdict.**
+
+**Overlap.** Near zero with the up-model axes in all three rounds — it found what they did not and
+missed what they found, which is row 3 of the table below (an independent eye), not row 1. Cost
+was again roughly comparable per run, so the standing conclusion holds: use it to free a slot, not
+because it is cheap.
 
 ## Data point 5 (PR #88 / TODO:269, round 1) — the axis paid, and it pushed back on a false premise
 


### PR DESCRIPTION
Follow-up to #107. `metdsl-enforcement-change` §7 and `metdsl-review-loop` §Finally both
require this judgment at the end of the work, and require telling the user rather than
rewriting silently — so these four were proposed and approved before being written.

Each comes from something **measured** in that loop, not from a conclusion about it.

## 1. An extraction diff recipe

`metdsl-enforcement-change/references/verification.md`

PR #107 shipped a helper extraction that silently dropped an `orchestration_id.strip()`. A
padded id then resolved to a directory that does not exist, ownership failed,
`_cleanup_agent_tmp_root` refused, and the run kept its tmp scratch — the state the workspace
validator flags as leaked `*.py`. **The suite was green on both sides.** It was found by
diffing the extraction against the text it replaced, and by nothing else.

The skill already said hunk mutation is near-useless on a move. It did not say how to *read*
the move. The recipe compares `ast.unparse` per function with docstrings stripped, so a
reflow, a comment, or a docstring rewrite cannot hide a token.

**Run as written** against `4330bd6..81c6a52` it isolates exactly the one changed function;
over the whole branch it cut a 1449-line diff to four functions. That second half is the point
— it bounds what else could have been dropped, which is the question a green suite cannot
answer.

## 2. Verify a reviewer's POSITIVE claims by asking what it executed

`metdsl-review-loop/SKILL.md`

The skill had the negative-direction rule ("when told *only X caught it*, check the
measurement scope") and not this one. Twice in one round a reviewer traced a code path and
reported MATCHES on claims that two reviewers who *ran* them found false — two guards sat
above the invalidation, and an ownership guard returned silently.

**The tell is a verdict justified by structure** ("X runs before Y, so Y is covered") **rather
than by an observation** ("I called it with a blank token and the file survived").

## 3. The `git checkout --` rule's trigger point

`metdsl-review-loop/SKILL.md`

The rule existed, in those words, and I broke it in round 2 on the fix commit's own tests:
four uncommitted test edits destroyed, redone from context, an hour lost. It sits under
"Before you hand it over", which reads as round-0-only, while the hazard is **every ad-hoc
mid-round mutation** — reproducing a finding, checking a fix, testing a reviewer's mutant.
Named where that actually happens, together with the baseline rule, which reads the same way
and bites the same way.

This is `metdsl-enforcement-change` §7's "the rule was there but its trigger point was
elsewhere", not "the rule was missing".

## 4. Sonnet delegation data points 6-8

`metdsl-review-loop/references/sonnet-delegation.md`

The skill asks for a data point each time the axis runs. Three runs on #107: one real finding
(a document count wrong in a commit message, which both up-model reviewers missed while
disagreeing with each other about the number), one real mismatch (a key-order claim asserted
in a comment with nothing observing it), one clean.

**Two more refusals of false premises I had planted in its own checklist** — now three of
eight data points, so that is the axis's most reproducible behaviour rather than a one-off.

Where it is weak is recorded in the same entry, because both of item 2's failures came from
this axis: its checklist asks for many verdicts cheaply, so **for a control-flow claim, ask it
for the command rather than the verdict.**

## What is deliberately not here

No other judgment-rule violation to report — 1, 1-b and 1-c held. No dual-read pair created or
resolved, no failure-attribution hesitation, no conductor in-process substep touched, so those
three references are unchanged. Nothing written to memory: per `AGENTS.md` §Canonical record
placement, a permanently needed fact belongs in the repository, which is where these went.

## Verification

- `test_skill_citations` 34 tests OK; `test_development_doc_sync` + `test_readme_sync` 31
  tests OK. Code-fence balance checked in all three files.
- The recipe in item 1 was **executed before being written down**, against the real commits it
  cites.
- Mutation check over `origin/main...HEAD`: **5 hunks, 5 survivors, all prose** — expected and
  reported rather than hidden, per the skill's own rule that a documentation-only diff reports
  every hunk survived and that this is a measurement. The one mechanically checkable claim in
  the diff is the recipe, and it is checked by running it.
