### PR TITLE
Record what PR #116 taught the two review skills

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/SKILL.md
+++ b/.claude/skills/metdsl-enforcement-change/SKILL.md
@@ -150,6 +150,15 @@ copying as the starting point. The four traps, each of which cost a round:
   turn a true statement red — resolve a named constant before giving up, and make the failure name
   the repair. This is the easiest one to reintroduce, because pinning the spelling is three lines
   and pinning the members is fifteen
+- **When the rule is an ENUMERATION, couple element by element AT ITS STATEMENT POSITION, and
+  derive the count from the code.** "Does this token appear in the document" couples nothing the
+  moment the token appears for another reason — on PR #116 the check asserted each of three flags
+  appeared in the canonical document, and a reviewer deleted a whole channel bullet with the row
+  green, because the flag names also occur in that document's reproduce command and in an
+  unrelated bullet. What closed it was reading the section that HOLDS the enumeration and
+  requiring each element to OPEN its own bullet there. The count is the other half: a document
+  that says "three channels" and lists two is only wrong if something compares the two, and the
+  number belongs to the code
 
 **Before adding a check, ask whether the sites should exist.** The cheaper fix is this
 repository's ordinary practice — one canonical statement, everyone else cites it (`AGENTS.md`

--- a/.claude/skills/metdsl-enforcement-change/references/failure-routing.md
+++ b/.claude/skills/metdsl-enforcement-change/references/failure-routing.md
@@ -69,6 +69,38 @@ reading and confirming, not something known when it was written**.
   the handler, or **decide to ship the mismatch and write down why** (PR #57 took the third; a
   reviewer asked for it to be flagged as a conscious decision)
 
+## A branch a check gains when it starts DECLARING its tool's configuration (2026-08-28, PR #116)
+
+Adding a declared configuration to a tool invocation creates an exit status that did not exist
+before: **the invocation was refused**, as distinct from **the source was judged and failed**. The
+lint gate's `--select` is validated by the linter's own argument parser, so a rule code the
+installed build does not know exits without reading a file. Before the declared set the argv had
+no `--select` and the exit was unreachable.
+
+The routing table above sends "what the leaf can fix" to a content failure and everything else to
+a transport fail_closed — and the defect was that the gate never asked the question. `ok=false`
+became `failure_category="lint_findings"`, so a leaf was warm-resumed with an argv error as its
+excerpt and a file it has no write authority over as the thing to fix: the unwinnable loop of
+issue #110, in a place the fix for #110 created. A blank-slate reviewer found it in the last round
+of the loop.
+
+Three things worth keeping from how it was closed:
+
+- **The discriminator must not be an error string.** The obvious test — "exit 1 and the output
+  says `Error:`" — is a classification channel the checked source contributes text to, since file
+  names appear in diagnostics. What was used instead is the PRESENCE OF A VERDICT: an exit status
+  that cannot mean "there are findings".
+- **The first version over-refused, immediately.** It also refused an exit 1 that printed no
+  diagnostic line, and that false-refused a legitimate content-failure fixture whose output shape
+  it had not been measured against — one test run to surface, and the default error direction this
+  repository keeps recording.
+- **The half that could not be classified safely moved to LAUNCH.** A withdrawn code (the tool
+  knows it and refuses to select it) exits 1 like an ordinary findings run. Rather than parse
+  output, the declared invocation is run once over an EMPTY directory before the first leaf, where
+  a usable build reports `0 files scanned` and exits 0 — the whole answer is a bare exit status.
+  That is §3's "decide when it should surface" applied: whose fault, then where is the earliest
+  place it can be detected reliably, then keep the gate's refusal as the backstop.
+
 ## Attribution detail moved from SKILL.md (2026-08-25)
 
 The fuller statement of two rules `SKILL.md` §3 now carries compressed — when a correct

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -232,6 +232,16 @@ when a rule does not obviously apply:
      write the property instead and check it**
    - **Recording that a number "was right when written" does not stop the next rot.** Only
      changing the form stopped it
+   - **A BATCH EDIT THAT RAISES BEFORE IT WRITES LOSES THE EDITS THAT SUCCEEDED, and the commit
+     message then describes work that did not happen.** On PR #116 one script made three
+     corrections to a canonical document and asserted its way to a fourth; the fourth assertion
+     failed, the process exited before `write_text`, and I read the traceback as being about the
+     fourth alone — so three corrections the commit message claimed were never applied, and the
+     document shipped two rounds later still stating what the code had explicitly retracted. Two
+     rules, both cheap: **one write per edit, verified after the write** (re-read the file and
+     assert the new text is in it, not that the old text was in it), and **never let an assertion
+     for edit N+1 sit between edit N and its write**. A review round found it; nothing else could
+     have, because every symptom was in a document no test read
    - **And then verify the substitution RAN.** The remedy has its own failure mode: PR #98 escalated
      to scripted substitution after four hand-typed numbers came out wrong, and the very next commit
      shipped with **eight unsubstituted `{PLACEHOLDER}` tokens in its message**, directly under the
@@ -398,7 +408,7 @@ same run — it is a reason to re-run the positive verdicts your change actually
 
 ## Delegate verifiable work to sonnet
 
-**Operational conclusion (8 data points; the confound resolved in PR #72 by giving both models
+**Operational conclusion (9 data points; the confound resolved in PR #72 by giving both models
 the same checklist, the axis run as delegated in PR #88): sonnet ⊂ opus, with real misses.** Move **the mechanical-recomputation axis**
 permanently to sonnet and keep judgment on the up-model. Costs came out roughly equal, so "it is
 cheap, so run more" does not hold — **use it only to free up a slot**. Run one via `Agent` with
@@ -427,7 +437,9 @@ numbers" does not give "it matches on parser semantics". **Measure per axis.**
 
 **Tell it to report claims it cannot locate rather than accounting for them** — refusing a false
 premise I had put in its prompt is the most valuable thing this axis has done — and the most
-reproducible, having now happened in three of the eight data points (5, and twice on PR #107).
+reproducible, having now happened in four of the nine data points (5, twice on PR #107, and on
+PR #116, where it reported that the ten-item mutant list a commit message referenced was recorded
+nowhere it could find — true, and the thing I would least have checked myself).
 **This stays an experiment**: collect real/total findings, elapsed time and the overlap count,
 add a data point each time, and delete this section if it stops paying. How to read overlap, how
 not to confound the comparison, and why the reverse (opus reviewing sonnet's implementation) is
@@ -832,6 +844,23 @@ that tells you how it closed.
 - **A witness test's probe value contains the implemented value as a substring** → the assertion is
   automatically true via another clause (`"cmake"` contains `"make"`). **Assert inside the test
   that the probe has the property it needs**
+- **Your assertion searches a TOOL'S OUTPUT for a code, a name, or a marker** → check what else
+  that output carries. A linter, a compiler and a test runner all ECHO THE SOURCE LINE under the
+  diagnostic, so `assertIn("C122", stdout)` matches the very `! allow(C122, …)` comment whose
+  suppression the test is meant to disprove. On PR #116 that made the single behavioural witness
+  for a security fix pass with the fix REVERTED, leaving one string equality on the argv between a
+  reproduced `leaf shortcut` and a green suite. **Parse the structured form** (the diagnostic
+  line's `path:line:col: CODE` shape, or `--output-format json`) **and add the negative control**:
+  the same input WITHOUT the mechanism must lose exactly what the mechanism was supposed to keep.
+  This is `metdsl-enforcement-change`'s surface 5 — caller-controlled data mixed into a
+  classification channel — asked of a TEST rather than of a gate
+- **You added a prose pin: construct the document SAYING THE OPPOSITE and run it** → a pin that a
+  document mentions the rule is not a pin that it states the rule. On PR #116 three leaf-read
+  contracts were held to not CARRYING a forbidden directive and to citing where the rule lives;
+  replacing each prohibition with its exact reversal ("… is the accepted way to clear a stubborn
+  style finding") passed 1294 tests. **The reversal is the mutation for a prose pin**, and the
+  literal you require should be DERIVED from the code (the flag, the constant) so a rename breaks
+  both together
 - **You measured a family and reported the conclusion** → ask whether the family could have come
   out the other way. **Two checks, and the second is the one that finds things.** (a) Name a member
   for which the measurement could have failed; if you cannot, you measured a family that

--- a/.claude/skills/metdsl-review-loop/references/measurement-records.md
+++ b/.claude/skills/metdsl-review-loop/references/measurement-records.md
@@ -61,3 +61,24 @@ The corpus sweep that would have caught it is one loop: every `workspace*/orches
 with a `launches/*.http_response.txt`, run through the instrument. It found two runs, and took
 under a minute.
 
+## PR #116 — three corrections a script reported as made, and never wrote
+
+One `python3 - <<PY` block made three replacements in a canonical document and then asserted the
+presence of a fourth. The fourth assertion failed, the process exited, and `write_text` — the last
+statement in the block — never ran. The traceback named the fourth replacement, so I fixed that one
+in a follow-up script and moved on. The three that had "succeeded" were discarded with the process.
+
+What shipped for two more rounds: a document stating that the invocation closed TWO channels while
+the code closed three and its own module docstring said the count was stated *because an earlier
+version said two and was wrong*; a paragraph promising a diagnostic the same commit had measured
+false and removed from four other documents; and an unqualified requirement whose measured
+counter-example two other files cited THAT document as recording. The commit message described all
+three as done. A disclosure round found it by reading the document.
+
+The rules this produces are in `SKILL.md` §"Before you hand it over" item 2. Both are mechanical:
+**one write per edit, verified by re-reading the file after the write** — asserting the OLD text was
+present proves nothing about whether the new text landed — and **never place an assertion for edit
+N+1 between edit N and its write**. The general form is the same one the placeholder episode above
+teaches: the remedy for hand-typed numbers has its own failure mode, and so does the remedy for
+hand-edited prose. Verify the write, not the intent.
+

--- a/.claude/skills/metdsl-review-loop/references/signs-episodes.md
+++ b/.claude/skills/metdsl-review-loop/references/signs-episodes.md
@@ -109,3 +109,29 @@ the case history that tells you how it closed.
   probe is individually fine, and only the SET is wrong — nothing in any one of them looks off, so
   it survives review by anyone who reads the test rather than asking what the family spans
 
+- **Your assertion searches a TOOL'S OUTPUT for a code, a name, or a marker** → PR #116, and the
+  most expensive single test defect this loop has produced. The change closed a `leaf shortcut`: a
+  leaf could put `! allow(C122, C131, C061, PORT011, C003)` above a `module` statement and take a
+  five-finding module to `All checks passed`. The fix added `--ignore-allow-comments`; the witness
+  asserted `assertIn("C122", completed.stdout)` for each suppressed code, plus a non-zero exit.
+  **Every one of those substrings is present when the fix is REVERTED**, because the linter prints
+  the offending source line under each diagnostic — and the offending line here is the allow
+  comment itself, which names all five codes. The exit stayed 1 through an unrelated finding the
+  directive did not name. So reverting the security half of the fix left one `assertEqual` on the
+  argv as the only failure, and a reviewer reproduced exactly that. The rewrite parses
+  `path:line:col: CODE` and adds the control the sibling row already had — the same input without
+  the flag must LOSE those codes. Two rows in that file now carry such a control; the one that did
+  not is the one that broke
+- **You added a prose pin: construct the document SAYING THE OPPOSITE and run it** → PR #116 again,
+  one round later. Four leaf-read contracts were coupled by three rows: no copyable
+  `! allow(<code>)` spelling anywhere in the file, every rule code named must be one the repository
+  has a position on, and each region must cite where the set is defined. A blank-slate reviewer
+  replaced each prohibition with its reversal — "an `! allow(...)` comment above the offending line
+  is the accepted way to clear a stubborn style finding" — and **1294 tests passed**. All three
+  rows are about what the document CARRIES; none is about what it ASSERTS. The fix requires each
+  region to contain the flag that makes the rule true, derived from `CHECK_FLAGS` so a rename
+  breaks the code and the documents together, and self-tests the detector against the reversal that
+  passed. Note which side of the tree was already safe: the PURE prompt template was pinned by a
+  token literal in `tools/tests/test_pure_leaf_wiring.py` and its reversal died there. The agentic
+  path — including the one document every `generate` leaf is force-read — had no counterpart
+


### PR DESCRIPTION
Follow-up to #116 (issue #111). Five review rounds on one branch; the three lessons worth keeping were all about how the review was RUN, not about what it reviewed.

## `metdsl-review-loop`

- **A batch edit that raises before it writes loses the edits that succeeded.** One script made three corrections to a canonical document and asserted its way to a fourth; the fourth assertion failed, the process exited before `write_text`, and I read the traceback as being about the fourth alone. Three corrections the commit message claimed were never applied, and the document shipped two more rounds stating what the code had explicitly retracted. Rule: one write per edit, verified by re-reading the file AFTER the write, and never place the assertion for edit N+1 between edit N and its write.
- **New mid-loop sign — an assertion that searches a tool's output for a code can match the tool's own ECHO of the source line.** The witness for the branch's security fix asserted each suppressed rule code appeared in stdout; all of them are present with the fix reverted, because the line the linter prints back under each diagnostic IS the allow comment naming those codes. Reverting the fix left one argv string equality between a reproduced `leaf shortcut` and a green suite. Parse the structured form, and add the negative control. Surface 5 of the sibling skill, asked of a test rather than of a gate.
- **New mid-loop sign — construct the document saying the OPPOSITE and run it.** Three coupling rows held four leaf-read contracts to not carrying a forbidden directive and to citing where the rule lives; replacing each prohibition with its exact reversal passed 1294 tests. Derive the required literal from the code so a rename breaks both together.
- Sonnet delegation gains a ninth data point; the axis refused a false premise for the fourth time in nine.

## `metdsl-enforcement-change`

- **Rule 3-a gains a fifth trap.** An enumeration couples element by element, at its statement position, with the count derived from the code — "does this token appear in the document" couples nothing once the token appears for another reason. Measured: a reviewer deleted a whole channel bullet with the coupling row green, because the flag names also occur in the document's reproduce command.
- **`references/failure-routing.md` gains the branch a check acquires when it starts DECLARING its tool's configuration.** The invocation can now be REFUSED, which is not the source being judged and failed; reading the first as the second sends a leaf to fix a file it cannot write. Kept from how it was closed: the discriminator must not be an error string, the first version over-refused immediately, and the half that could not be classified safely moved to launch.

Documentation only — no code, no test behaviour. Suite unchanged at 5396 passed / 10 failed in the primary checkout, the 10 being this checkout's pre-existing failures on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brgnzx3dXMbQMkx1mr32Wo