### PR TITLE
Run the covering test FILE on origin/main before diagnosing (metdsl-enforcement-change)

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/SKILL.md
+++ b/.claude/skills/metdsl-enforcement-change/SKILL.md
@@ -84,6 +84,11 @@ to **one unbilled observation**).
 - **Observation costs two orders of magnitude less than implementation**
 - **"It was not refused" cannot be shown from refusal logs.** In a layer where refusals leave no
   event, **count the traces on the success side**
+- **Before diagnosing a defect in enforcement machinery, run the suite FILE that covers it on
+  `origin/main` and read what fails.** The bug is often already a red test there, and that is the
+  strongest evidence a causal argument can have — but the FULL-suite verdict hides it behind the
+  known baseline failures, so the whole-tree number is not the place to look. Seconds to run
+  (`references/verification.md` §The suite)
 - When a premise collapses, **keep the measurements**. The plan dies; the measured facts stay
 
 **1-e. "Out of scope because the leaf gains nothing" is a classification rule 1 does not govern.**

--- a/.claude/skills/metdsl-enforcement-change/references/verification.md
+++ b/.claude/skills/metdsl-enforcement-change/references/verification.md
@@ -14,6 +14,35 @@ while developing this repository.
 python3 -m pytest tools/tests/ -q -p no:randomly
 ```
 
+- **Before you diagnose a defect, run the FILE that covers the mechanism on `origin/main`.**
+
+  ```bash
+  git worktree add --detach <scratch>/main origin/main
+  (cd <scratch>/main && python3 -m pytest tools/tests/<the file> -q -p no:randomly)
+  ```
+
+  Issue #113 was a freshness gate comparing a `time.time()` instant against a file mtime — two
+  different clocks, so a deterministic in-process body that finished inside one timer tick failed
+  its own gate. `tools/tests/test_workflow_conductor.py` was **8 failed / 761 passed on
+  `origin/main`** for exactly that reason (`VerifyMetaSchemaWarmResumeTests` and both copies of
+  `test_retried_judge_cannot_certify_the_dead_attempts_semantic_review`, whose stubs write their
+  metas in-process), and it went to 770 passed on the branch. Nobody noticed for two rounds: I
+  argued the cause from one incident's artifacts and from a timing measurement, a reviewer showed
+  the arithmetic did not carry, and only then did another reviewer run the file on `main`. **The
+  strongest evidence a causal argument in this repository can have is often already a red test on
+  `main`, and it costs seconds.**
+
+  **Why the full-suite run does not surface it**: the whole-tree verdict here is "2 failed /
+  ~5460 passed", those two being the standing path-depth-coupled `ForbidBackendCredentialReadTests`
+  cases, and a branch that FIXES eight failures elsewhere reports the same two. The delta rule
+  below compares totals, and eight fewer failures reads as eight more passes among thousands. Run
+  the file, read the failure NAMES.
+
+  Two directions, both worth the seconds: failures on `main` that your branch turns green are
+  evidence FOR your diagnosis (say so in the commit — I did not, and a reviewer had to); failures
+  your branch does not touch are the baseline you must name before anyone else reads them as
+  yours.
+
 - **Do NOT point `TMPDIR` at `/dev/shm`.** This section used to recommend it, and the
   recommendation cost two false failures on `main` and on a branch alike (measured 2026-08-21):
   `test_hooks_common.py::DevShmWriteBlockTests::test_blocks_dev_shm_via_find_traversal` and


### PR DESCRIPTION
Follow-up to #123. One rule and one episode, no code.

## What happened

Issue #113's causal argument took two review rounds to get right, and the evidence that settled it
was in the repository the whole time. `tools/tests/test_workflow_conductor.py` was **8 failed /
761 passed on `origin/main`** (`e64b50a`) for exactly the bug under diagnosis — in-process stubs
writing their metas inside one timer tick of a `time.time()` launch instant — and **770 passed**
on the branch.

I argued the cause from one incident's artifacts plus a timing measurement instead. A reviewer
showed that arithmetic silently needed an unmeasured `record-launch` teardown term, and a second
reviewer found the red tests on `main`. Both numbers are re-taken here at `ec8f7dc`.

## Why the full-suite run does not surface it

This suite's whole-tree verdict is "2 failed / ~5460 passed", those two being the standing
path-depth-coupled `ForbidBackendCredentialReadTests` pair. A branch that FIXES eight failures
elsewhere reports the same two — eight fewer failures reads as eight more passes among thousands,
and the existing "compare the DELTA" rule is about totals. The file-level run reports the failure
NAMES, which is what a diagnosis needs.

## Where it goes

- `SKILL.md`, judgment rule **1-d** ("the premises of a fix you have not written yet are also a
  classification"), which already says to execute a premise before implementing on it. This is
  the cheapest instance of that rule in this repository and it was not obvious to me.
- `references/verification.md` §The suite, as its **first** bullet — ahead of the delta rule,
  which is what a reader would otherwise reach for.

Stated in both directions, because only one of them is about being right: failures on `main` that
the branch turns green are evidence FOR the diagnosis and belong in the commit message (#113's did
not, until a reviewer put them there); failures the branch does not touch are the baseline to name
before someone else reads them as yours.

## Verification (primary checkout, at `ec8f7dc`)

`tools/tests/test_workflow_conductor.py` 770 passed / 1111 subtests; `test_skill_citations.py` +
`test_development_doc_sync.py` 59 passed / 67 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brgnzx3dXMbQMkx1mr32Wo
