### PR TITLE
Write four procedures the issue #120 loop cost into the review-loop and enforcement skills

### DIFF
--- a/.claude/skills/metdsl-enforcement-change/SKILL.md
+++ b/.claude/skills/metdsl-enforcement-change/SKILL.md
@@ -24,7 +24,7 @@ here that does not obviously apply to your case is answered in its reference fil
 guessing.
 
 - `references/judgment-episodes.md` — what each judgment rule below cost, in full
-- `references/input-surfaces.md` — surfaces 5-9, the marker-narrowing version table, the recipes
+- `references/input-surfaces.md` — surfaces 5-10, the marker-narrowing version table, the recipes
 - `references/source-text-surface.md` — the spelling variation a source-text-reading gate must survive
 - `references/dual-read-pairs.md` — the table of facts two layers read
 - `references/failure-routing.md` — attribution criteria, the known branches, and remedy wording
@@ -202,7 +202,7 @@ When a rule derives its safety from an enumeration, **write a test that kills ea
 enumeration by mutation** (round 0 in `metdsl-review-loop`). A missing element shows up in no
 other test.
 
-The five surfaces that are none of exec / env / argv / FS / evidence paths and none of the
+The six surfaces that are none of exec / env / argv / FS / evidence paths and none of the
 spelling variation. Each is one question; the episodes, the version tables and the measurement
 recipes are in `references/input-surfaces.md`:
 
@@ -267,6 +267,22 @@ recipes are in `references/input-surfaces.md`:
   And **attribution is not enforcement** — roots are sorted longest-path-first, so a new entry
   beneath an existing one silently takes over the block message; keep a control read that must
   still be attributed to the root above
+- **Surface 10 — when a gate delegates its verdict to an external tool, can that tool decline to do
+  the work and report SUCCESS?** A gate that reads an exit status is trusting the tool to have
+  looked. Tools bound their own effort — a configuration cap, a time or memory limit, a walk that
+  skips what it cannot read, a parse it abandons — and the honest ones then say so **on a channel
+  the gate is not listening to**. PR #125: `cppcheck` analyses at most 12 preprocessor
+  configurations and stops, exiting **0** over source it never analysed; the only trace is
+  `[toomanyconfigs]`, whose severity is `information`, which the declared severities did not
+  enable. A leaf that cannot satisfy a finding wraps the file in `#ifdef`s and the gate passes.
+  **Rule: enumerate the tool's OWN limits from its `--help`, not its failure modes**, and for each,
+  ask what it reports and where. **Prefer removing the cap to raising it** — `--max-configs=N` only
+  moves the hole to `N+1`, `--force` removes it — and check the degenerate case fails CLOSED (there,
+  a timeout arrives as `return_code: None`, which the conductor already refuses). **The tell is a
+  tool that reports partial work as completion**, and every family this repository delegates to has
+  one: a linter's walk exclusions and read errors, a compiler's error cap, a test runner's
+  collection error, a build system's `-k`. Related but different from surface 5 — nothing here is
+  caller-controlled; the tool is simply answering a narrower question than the gate asked.
 
 ### 2. Confirm the path production actually takes
 

--- a/.claude/skills/metdsl-enforcement-change/references/input-surfaces.md
+++ b/.claude/skills/metdsl-enforcement-change/references/input-surfaces.md
@@ -1,4 +1,4 @@
-# Input surfaces 5-9: the episodes behind them
+# Input surfaces 5-10: the episodes behind them
 
 Moved out of `SKILL.md` verbatim (2026-08-25). `SKILL.md` §1 "Inventory the surface before
 fixing" keeps each surface's question and its rule in a few lines; this file is what each one
@@ -189,4 +189,61 @@ not.
   block message for everything under it. The read stays refused; the id in the message changes,
   and any test or document that named the old id becomes false. Check both, and keep a control
   read that must still be attributed to the root above
+
+## Surface 10 — the tool declined to do the work and reported success
+
+PR #125 (issue #120), found by a round-3 security axis after two rounds had attacked the same
+backend and missed it. It is the only reachable `leaf shortcut` that branch produced, and the
+mechanism is the tool's, not the gate's.
+
+`cppcheck` analyses at most **12** preprocessor configurations and then stops. Measured identically
+on 2.7, 2.16.0 and 2.17.1, under the gate's own declared argv:
+
+    defect inside the 20th `#ifdef`, 19 padding blocks before it   -> exit 0
+    the same block alone                                           -> exit 2
+
+Same source body, same argv, same build; the verdict flips on how much dead conditional precedes
+it. The gate reads `proc.returncode == 0` and records `ok=true`, so `Generate.gate` certifies
+source the tool never looked at.
+
+**What made it invisible for two rounds.** The tool DOES say so — `Too many #ifdef configurations
+- cppcheck only checks 12 configurations` — but the message carries severity `information`, and
+the declared severity set did not enable `information`. So the warning existed on a channel the
+gate was not listening to, and the only thing the gate WAS listening to said success. Two earlier
+rounds enumerated this backend's channels, its config discovery, its suppression directives and
+its exit statuses; none asked whether the tool bounds its own effort, because that is not an input
+surface in the ordinary sense — nothing about it is caller-controlled.
+
+**Why `--force` rather than `--max-configs=N`.** A cap of `N` has the same hole at `N+1`. Removing
+the cap is the closure; raising it is a bigger number. The cost has to be checked in the same
+breath, and the degenerate case must fail CLOSED rather than pass: measured, `--force` changed no
+verdict and no measurable time on the checked-in fixture, and a source adversarial enough to make
+it expensive hits `run_linter`'s `timeout_sec`, which arrives as `return_code: None` and is
+already a transport `fail_closed`.
+
+**The procedure is validated on this instance, and that is worth stating because it is the part
+that generalises.** `cppcheck --help` carries the whole thing without running anything:
+
+    --max-configs=<limit>   Maximum number of configurations to check in a file
+                            before skipping it. Default is '12'. …
+    -f, --force             Force checking of all configurations in files.
+
+The cap, its default and the flag that removes it, in one entry — and the runtime message names the
+channel too (`For more details, use --enable=information`). Nobody read it for three rounds. The
+string an investigator naturally greps for afterwards, `only checks 12 configurations`, is in
+`--errorlist`, NOT in `--help`; the `--help` spelling is `Default is '12'`. Grep for the flag names
+and for `default`, not for the sentence the tool prints when it fires.
+
+**The general procedure**, which is cheap and was never run on any of the three linter backends
+before this: read the tool's `--help` for the limits it imposes on ITSELF — configuration caps,
+error caps, time and memory limits, "only the first N", walk exclusions, files it declines to read
+— and for each ask two questions: what does the tool report, and is the gate listening to that
+channel. Every family this repository delegates a verdict to has at least one: a linter's walk
+exclusions and read errors (both recorded as non-closures on the same branch), a compiler's
+diagnostic cap, a test runner's collection error, a build system's `-k`.
+
+**Not surface 5.** Surface 5 is caller-controlled data reaching the classification channel, and
+the fix there is to change the channel. Here nothing is caller-controlled — the tool is answering
+a narrower question than the gate asked, and saying so somewhere else. The fix is to stop it
+narrowing, or to listen where it says it did.
 

--- a/.claude/skills/metdsl-review-loop/SKILL.md
+++ b/.claude/skills/metdsl-review-loop/SKILL.md
@@ -777,9 +777,16 @@ code:
 **The move that finds them: spend one round on the disclosure axis alone**, with no functional
 brief, **before stopping rather than as an extra round after deciding to stop**. Two briefs:
 "verify every claim in the commit messages at HEAD" and "read it as the next maintainer: what
-would mislead you, can the deletion's measurement be re-taken from what is written, what does a
-LEAF see, what does an OPERATOR see, would you merge". If it returns first-category items, the
-record has not converged even though the enforcement code has.
+would mislead you, can the deletion's measurement be re-taken from what is written, **what CHECK
+went with what was deleted**, what does a LEAF see, what does an OPERATOR see, would you merge". If
+it returns first-category items, the record has not converged even though the enforcement code has.
+
+**The added clause is not a flourish.** On PR #125 it is what surfaced the branch's only blocker —
+a check `origin/main` had that a round-2 fix narrowed away — and no other instrument in this loop
+could have: the sweep mutates what exists, the census enumerates what exists, and a blank-slate
+reviewer reads HEAD. **Everything else compares HEAD against itself.** The disclosure round is the
+one place a reviewer is pointed at the previous revision, so it is the only place a deleted
+guarantee is visible.
 
 **For a change that adds checking machinery, run a witness census once.** Instruct a dedicated
 reviewer:
@@ -843,7 +850,19 @@ that tells you how it closed.
   got that sentence wrong in three consecutive rounds, each version written to fix the previous
   one. What closed it was DELETING the summary: state the figures, state what they are being
   compared against, and leave the comparison to the reader. A summary of a spread is a claim with
-  no witness; the spread itself has one
+  no witness; the spread itself has one.
+  **And when you do reach for the sweep, sweep the FACT, not the spelling.** PR #125 corrected one
+  figure three times, each correction sweeping the wording it had just written, and each missing a
+  different phrasing of the same measurement — the fourth spelling sat eleven lines from the third
+  and survived four rounds. Sweep for the NUMBER and for what it is a number OF, then read every
+  hit; a `grep` for last round's sentence finds last round's sentence
+- **A comment or docstring RESTATES a measurement the assertion beside it already carries** →
+  delete the restatement; do not correct it. Criterion: could this sentence and the line under it
+  disagree? Then they will, and the sentence is the one that will be wrong, because nothing runs
+  it. PR #125's four-round figure lived three lines above `assertEqual(..., [])` saying something
+  the assertion contradicted, and each round corrected the prose rather than asking why a
+  measurement was stated twice. **This is not the "prose that enumerates entities" row**: that one
+  says turn prose into a check, this one says the check is already there
 - **A term you coined for a tool has appeared in a document as if the system used it** → check it
   against the vocabulary the repository already defines. On PR #100 a reporting script labelled any
   body it could not parse "body is not an event stream", and that phrase was then written into
@@ -857,6 +876,16 @@ that tells you how it closed.
   readers) → **re-measuring loses. Turn it into a check.** Criterion: should this prose break if
   one test is renamed? Then make it a check (the general form, and when a check is the wrong
   answer, is rule 3-a — this row is the enumeration case of it)
+- **Your fix NARROWS a check to stop it over-refusing** → the OLD check is a mutant, and you owe
+  it a run against BOTH revisions. Narrowing is the standard fix for over-refusal and it removes
+  coverage by construction; what you have to establish is that what it stops catching is only the
+  legitimate input. Procedure, two commands: take the defect the old check caught, apply it at
+  `origin/main` and at `HEAD`, and require red-then-red. Red-then-GREEN is the finding. PR #125
+  narrowed a whole-document version-range identity to one table column and un-pinned the operator's
+  own install line with it — drifting `pipx install 'fortitude-lint>=0.8,<0.10'` to `<0.11` left
+  HEAD green and `origin/main` red, and no round noticed until the disclosure axis read the branch
+  as the next maintainer. **Nothing else in this loop looks backwards**: every other instrument
+  compares HEAD against itself, so a check the branch deleted is invisible to all of them
 - **A fix changed the shape of the rule** (denylist → allowlist and the like) → split everything
   after that into another PR. If you continue without splitting, **give the user the options and
   ask**

--- a/.claude/skills/metdsl-review-loop/references/signs-episodes.md
+++ b/.claude/skills/metdsl-review-loop/references/signs-episodes.md
@@ -134,4 +134,50 @@ the case history that tells you how it closed.
   passed. Note which side of the tree was already safe: the PURE prompt template was pinned by a
   token literal in `tools/tests/test_pure_leaf_wiring.py` and its reversal died there. The agentic
   path — including the one document every `generate` leaf is force-read — had no counterpart
+- **Sweep the FACT, not the spelling** → PR #125, issue #120. One measurement — what a discovered
+  `per-file-ignores` key does to a five-finding fixture — was written into three places as "five
+  findings to one" when the answer is five to NONE, and the assertion three lines below one of
+  those places read `assertEqual(_reported_codes(...), [])`. Round 2 corrected all three and its
+  commit message said, correctly, that "a rewrite that touches a sentence and does not re-read the
+  clause it is attached to is how both of these survived" — and then did it: an eleventh line below
+  the comment it had just fixed, in the same file, in the same commit, sat "the same file silences
+  four of the five". My sweep after that commit searched `five findings to one` and `four channels`;
+  the survivor was a THIRD spelling of the same fact and was found by a reviewer, not by me, one
+  round later. Four rounds, three spellings, one number.
+  **Two lessons, and the second is the one that closed it.** Sweep for the NUMBER and for what it is
+  a number OF, then read every hit — a `grep` for last round's sentence finds last round's sentence.
+  And the fourth correction was not a correction: the comment was DELETED. It restated a measurement
+  the assertion beside it already carried, so the two could disagree and only one of them ran.
+  Related and different: the `TODO.md` figures for this repository's own `ruff` count are a
+  *dated record* and are correct as such; what rots is a claim about the present.
+- **A comment or docstring RESTATES a measurement the assertion beside it already carries** →
+  the same PR #125 episode, read from the other end. The question that would have closed it in round
+  1 is not "is this figure right" but "why is this measurement written twice". A test's assertion is
+  executed on every run; the sentence above it is executed by nobody. Wherever the two can disagree,
+  the sentence is the half that will be wrong, and correcting it buys one round.
+  **Do not confuse this with "prose that enumerates entities in the code"**, which says turn prose
+  into a check. Here the check already exists; the prose is the redundant copy, and the fix is
+  subtraction. The tell is that the sentence and the line under it are about the same measurement.
+- **Your fix NARROWS a check to stop it over-refusing** → PR #125, and it produced the only
+  BLOCKER of that branch's disclosure round. `origin/main` carried
+  `test_every_version_range_the_runbook_states_is_the_declared_one`, set identity over EVERY
+  `>=x.y,<a.b` in `docs/RUNBOOK.md`, with a docstring saying why: it "makes an operator's install
+  line and the launch refusal impossible to disagree". Round 2 of that loop found it over-refusing —
+  any legitimate `python3` or `cmake` prerequisite documented in the operator's own runbook turned
+  the suite red with a message blaming the document for a linter fact — and narrowed it to the
+  §0-1 table's range column. Correct fix, real over-refusal, and it deleted the coverage of the one
+  line an operator actually types. Measured in the disclosure round: drifting
+  `pipx install 'fortitude-lint>=0.8,<0.10'` to `<0.11` left **HEAD green and `origin/main` red**.
+  **Why no instrument saw it.** The mutation sweep mutates what exists; the census enumerates what
+  exists; a blank-slate reviewer reads HEAD. Every instrument in this loop compares HEAD against
+  itself, so a check the branch REMOVED is outside all of them. Only a reader who went looking for
+  what was deleted found it, and the brief that sent them was "is anything DELETED whose measurement
+  can no longer be re-taken".
+  **The procedure is two commands and it is cheap.** Take the defect the old check caught, apply it
+  at `origin/main` and at `HEAD`, require red-then-red, and treat red-then-green as the finding. Run
+  it in the same commit as the narrowing, because the narrowing is where the knowledge of what the
+  old check caught is at its freshest. The eventual fix on that branch was a scope BETWEEN the two —
+  any range on a line naming a linter's executable must be that linter's — which catches the install
+  line and cannot fire on a prerequisite that names no linter; the general shape is that a
+  narrowing usually has a middle, and "whole document" versus "one column" was a false choice.
 


### PR DESCRIPTION
Four procedures the issue #120 review loop (#125) cost, written into the two skills that own them.
Rules in `SKILL.md`, episodes in `references/`, per each file's own split.

## `metdsl-review-loop`

**1. The sweep has to be over the FACT, not the spelling.** The existing sign — a string rewritten
three times is a sweep problem — fired, I swept, and the sweep missed: I searched the wording I had
just written, and the survivor was a third phrasing of the same measurement, eleven lines from the
second. One figure, three spellings, four rounds. The row now says to sweep for the NUMBER and for
what it is a number OF, and to read every hit.

**2. A comment that restates a measurement its own assertion carries is a defect by construction,
and the fix is subtraction.** That figure sat three lines above `assertEqual(..., [])` saying
something the assertion contradicted; three rounds corrected the prose and none asked why the
measurement was written twice. The assertion runs on every suite; the sentence runs never. Stated
apart from the existing "prose that enumerates entities" row, which says turn prose INTO a check —
here the check is already there and the prose is the copy.

**3. A fix that narrows a check owes the old check a run against both revisions.** Round 2 of that
loop found a check over-refusing, narrowed it correctly, and deleted with it the coverage of the
one line an operator actually types: drifting `pipx install 'fortitude-lint>=0.8,<0.10'` to `<0.11`
left HEAD green and `origin/main` red. That was the branch's only blocker and it survived three
rounds.

The reason it survived is structural and is now written down: **every instrument in that loop
compares HEAD against itself** — the mutation sweep mutates what exists, the census enumerates what
exists, a blank-slate reviewer reads HEAD — so a check the branch REMOVED is outside all of them.
The procedure is two commands (apply the defect the old check caught at `origin/main` and at HEAD;
require red-then-red) and belongs in the narrowing commit. The disclosure brief gains "what CHECK
went with what was deleted" for the same reason: it is the one brief that points a reviewer at the
previous revision.

Also recorded, worth more than the instance: **a narrowing usually has a middle.** "Whole document"
versus "one table column" was a false choice, and what shipped was neither.

## `metdsl-enforcement-change` — surface 10

**When a gate delegates its verdict to an external tool, can that tool decline to do the work and
report SUCCESS?** `cppcheck` analyses at most 12 preprocessor configurations and then stops:
measured on 2.7 / 2.16.0 / 2.17.1 under the gate's declared argv, a defect inside the twentieth
`#ifdef` exits **0** while the same block alone exits 2. The gate reads `returncode == 0` and
certifies source the tool never looked at.

What made it invisible for two rounds is the shape worth naming: the tool DOES say so
(`[toomanyconfigs]`), but on severity `information`, which the declared set did not enable. The
warning was on a channel the gate was not listening to; the channel it WAS listening to said
success.

**Not surface 5.** That one is caller-controlled data reaching the classification channel, fixed by
changing the channel. Here nothing is caller-controlled — the tool answers a narrower question than
the gate asked and says so elsewhere.

Two further rules, both measured: prefer removing a cap to raising it (`--max-configs=N` moves the
hole to `N+1`), and check the degenerate case fails CLOSED (`--force` changed no verdict and no
measurable time; an adversarial source hits `run_linter`'s `timeout_sec`, which arrives as
`return_code: None` and is already a transport fail_closed).

## Verification, and its limits

- `tools/tests/test_skill_citations.py` and `test_backend_boundary.py`: 120 passed, 10 subtests.
- Every measurement quoted in the new text was re-executed before committing — the exit codes on
  two cppcheck builds, the `toomanyconfigs` severity, and the `--help` entries.
- **One of my own new rules failed its own execution check and was corrected before commit.** I
  wrote "enumerate the tool's limits from its `--help`", then ran it: `grep "only checks 12
  configurations" --help` returns nothing, because that phrasing is in `--errorlist`. The rule
  holds — `--help` carries `--max-configs=<limit> … Default is '12'` and `-f, --force` — and the
  reference now records the grep trap with it: sweep for the flag names and for `default`, not for
  the sentence the tool prints when the limit fires.
- Adding a surface made "surfaces 5-9" and "The five surfaces" false. Both were found by sweeping
  for the FACT rather than a spelling, which is rule 1 of this same PR applied to itself.

**Not review-looped.** This is a documentation change to two skill files with no enforcement
behaviour and thin test coverage by design (`.claude/` is outside the backend-boundary scope). The
episodes it records were all established by execution during #125; what is unverified here is
editorial — whether these are the right four rules and whether they are stated at a useful
altitude. Happy to run a round on it if you would rather not take that on the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Brgnzx3dXMbQMkx1mr32Wo
