### PR TITLE
skills: what issue #143's loop taught, in the files that own them

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -139,7 +139,7 @@ operator does not lower the count — it decides which site you check first.
 **Reach for the pattern this repository already uses three times** (`_SCRATCH_SURFACES`,
 `_REDIRECT_RULE_SURFACES`, `_SURFACES` in `tools/tests/test_hooks_cli.py`) — but they are three
 DIFFERENT shapes and **they duplicate each other**, so read the one nearest your rule and treat
-copying as the starting point. The four traps, each of which cost a round:
+copying as the starting point. The six traps, each of which cost a round (the count was wrong here — "four" over five bullets — until issue #143 added the sixth, which is this rule's own enumeration trap turned on itself):
 
 - **Anchor on text that PRECEDES the rule and is byte-identical in the wording you are refusing.**
   Anchoring on your own corrected sentence pins that the correction survived, not that the rule is
@@ -164,6 +164,23 @@ copying as the starting point. The four traps, each of which cost a round:
   requiring each element to OPEN its own bullet there. The count is the other half: a document
   that says "three channels" and lists two is only wrong if something compares the two, and the
   number belongs to the code
+- **An EXEMPTION is a rule too, and it gets broken from both sides.** When the check must let
+  something through — a routing sentence that legitimately names the thing you are refusing —
+  do not decide the exemption by pattern. Issue #143 tried "the line cites the phase doc", then
+  "cites it WITH the section pointer", and one review round broke both directions at once: a
+  hand-assignment written WITH the pointer passed, while correct routing prose about another
+  phase's rule was refused with a message calling it an assignment, whose only satisfying edit
+  made the document wrong. Deciding "routes" from "assigns" by pattern is §1's source-text
+  surface asked of an exemption, and it loses the same way. **What closed it: an explicit
+  allowlist of the exempt lines, compared as a set** — a new mention of any wording is refused
+  until someone reads it and adds an entry, which is a review gate rather than a judgment, and
+  adding one is a line. Two follow-through traps, both hit on the same branch: **normalize the
+  allowlist entry to the WHOLE line** (a 60-character prefix let an assignment ride on an
+  allowlisted line's tail — a new mention, which the check advertised as always red — so each
+  entry carries a digest of the full line), and **an emptiness set does not self-test its own
+  surface list**: deleting a surface that happens to carry no exempt line is invisible, which was
+  3 of 5 there, so derive the surfaces from the code that decides them
+  (`leaf_contract_doc_refs`) and assert the coverage
 
 **Before adding a check, ask whether the sites should exist.** The cheaper fix is this
 repository's ordinary practice — one canonical statement, everyone else cites it (`AGENTS.md`

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -871,6 +871,19 @@ that tells you how it closed.
   as the focus** in the next round's prompt. The more the change is a move or rename whose body is
   known correct, the more the review is really about **your own fixes** — put that instruction in
   from round 1
+- **The fix was to a RECORD, so you verified it by reading** → a record fix carries the same
+  defect rate as a code fix, and this is the sub-case of the row above that gets skipped, because
+  prose does not look like something you run. Criterion: **the corrected sentence must pass the
+  check the wrong one failed.** If the defect was "this key does not exist", resolve the new key
+  against the artifact; if it was "this count is wrong", compute the new count; if it was "this
+  function is not named", drive the function. PR #146 shipped three in a row — a half-followable
+  operator remedy replaced by an unfollowable one (a `failure_analysis.json` key nothing writes on
+  that route), a commit message that described the author's uncommitted working tree as the
+  previous commit's state, and a "measured" claim repeated from a reviewer's report without
+  re-running it. **And the check written to hold a corrected record must observe the thing the
+  record describes**: the first of those was pinned by asserting the key's name occurred in a
+  module — it did, in a CONSUMER the same sentence says never runs — so the check ratified the
+  error (`references/signs-episodes.md`)
 - **You have rewritten the same string three times** → the problem is not the rule but the prose
   citing it. Switch to the grep sweep
   (`.claude/skills/atmofab-enforcement-change/references/verification.md`). **Rewriting one

--- a/.claude/skills/atmofab-review-loop/references/class-descent-log.md
+++ b/.claude/skills/atmofab-review-loop/references/class-descent-log.md
@@ -319,6 +319,55 @@ descent not achieved, blank-slate zero-functional-defects not achieved twice. Th
 census is explicitly not closed — an independent census found 24 of 40 mutants surviving in round
 4, and the author's own 12-mutant sweep afterwards is a statement about those 12.
 
+## PR #146 / issue #143 — the first loop to run to the cap, and what the cap bought
+
+A rubric for choosing a `verify` verdict's `issue_severity`, defined once in a phase document and
+injected verbatim into the pure reviewer's prompt. Round 0 plus **five** rounds — the cap — with
+two subagents per round, no Codex (adds checking machinery AND a prose-centred diff: two of the
+three "better not to launch" cases). Ten `PURE_PROMPT_CONTRACT_VERSION` bumps' worth of leaf-input
+change ended at `pure-30`.
+
+**The class did not descend, and the shape of what did not descend is the point.** Round 1 found
+the DELIVERABLE wrong — the rubric's own drop clause was strictly wider than the two existing
+statements of the same rule, re-creating issue #142's failure class inside the text written to
+close #143, and the wording came from the approved plan. Every round after that found defects
+inside the previous round's fix, and rounds 3-5 found leaf- or operator-facing ones rather than
+weak pins:
+
+| Round | What the previous fix had introduced |
+|---|---|
+| 2 | the coupling that fixed round 1 pinned PRESENCE, not exclusivity (an appended widening passed); the over-refusal fix to the bullet counter threw away the enum closure it replaced |
+| 3 | a half-followable operator remedy replaced by an unfollowable one, pinned by a check that ratified it; an editing-note bound whose marker occurs zero times in the document, so the note could be gutted to say the opposite |
+| 4 | a commit claiming to delete a duplicate created one — four shadowed test methods, two of that round's own fixes in the dead half; the severity sweep's predicate broken from BOTH sides in one round; a checklist clause widened on the rubric side and not on its own |
+| 5 | a tie-break ordering the value its own `major` bullet forbids — and both sentences had been pinned literally in round 4, so the CONTRADICTION was pinned rather than caught |
+
+**Two lessons the histories above did not already carry.**
+
+1. **Record fixes fail at the same rate as code fixes and nobody re-runs them.** Three in this one
+   loop; `signs-episodes.md` §"The fix was to a RECORD" has them. This is the sub-case of "a
+   finding sits inside the previous round's fix" that gets skipped because prose does not look
+   like something you execute.
+2. **A pin can pin a contradiction.** Round 4 pinned both tie-break sentences positively, which was
+   the right move against a digest-only guard — and one of them ordered a verdict the rubric's own
+   `major` bullet forbids, so the literal pin froze the disagreement instead of surfacing it.
+   Pinning a sentence proves it survived; it proves nothing about whether it agrees with the
+   sentence three lines up. Round 5 found it by RENDERING the leaf's prompt and reading the
+   documents against each other, which no mutation sweep and no census can do.
+
+**What the cap bought.** Round 5 was the most productive round of the loop by severity: the
+shadowed-test-method defect (which had silently removed four of the branch's own checks), the
+tie-break contradiction, and an end anchor that made three documents' promise to the operator false
+(`## On-failure behavior and retry` still matched a word-boundary terminator). Stopping at the
+default of three would have shipped all three. That is not an argument for raising the cap — it is
+the cost side of the budget, recorded so the next reader can weigh it (§"The budget" below).
+
+**The shape changes the signs prescribe were all made, and all made late**: predicate → set identity
+(round 4, after the predicate was broken from both sides), source-substring pin → drive the
+artifact (round 4), re-enumerating a rule → defer to its single statement (round 5, after two
+successive half-fixes of the same enumeration). A loop that reached the cap with the shape changes
+only just landed is `SKILL.md`'s "five rounds without the class descending → the shape of the rule
+is wrong" arriving at the same reading from the other side.
+
 ## Census practical notes: the episode behind each (restored 2026-08-25)
 
 These six were compressed to one line each in `SKILL.md` §"Stopping conditions" and their

--- a/.claude/skills/atmofab-review-loop/references/mutation-testing.md
+++ b/.claude/skills/atmofab-review-loop/references/mutation-testing.md
@@ -103,9 +103,14 @@ hand against the checkout turned the file from 14 passed to 1 failed / 13 passed
 The wasted move was writing a second, weaker witness for a mechanism the first one already
 covered, on the strength of a survivor line.
 
-Measured rather than read from the source: with an untracked `tools/tests/_uncommitted_probe.txt`
-in the checkout and `--test-cmd "test -f tools/tests/_uncommitted_probe.txt"`, the run stops at
-**BASELINE RED** — the worktree does not have the file.
+Measured rather than read from the source: create an untracked probe file under
+`tools/tests/` — any name the repository does not track — and point `--test-cmd` at it with
+`test -f <that path>`; the run stops at **BASELINE RED**, because the worktree does not have
+the file. (Written with the probe's path spelled out until 2026-09-03, which made it the
+repository's only standing suite failure: `test_skill_citations` reads a backticked
+repo-relative path in a skill file as a POINTER and requires it to be tracked, and the whole
+point of this one is that it is not. The rule is right and the citation was the defect —
+name the shape, not a path a reader would try to open.)
 
 The behaviour is right and should not change: a sweep that mixed in uncommitted work would
 report about a tree no one can reproduce. What the rule has to say is the ORDER — commit the

--- a/.claude/skills/atmofab-review-loop/references/signs-episodes.md
+++ b/.claude/skills/atmofab-review-loop/references/signs-episodes.md
@@ -9,6 +9,51 @@ the case history that tells you how it closed.
   with zero defects in the moved code itself and everything in the fixes and the prose). The more
   a change is a move or rename where the body is known correct, the more the review is really about
   **your own fixes** — put the focus instruction in from the first round
+- **The fix was to a RECORD, so you verified it by reading** (PR #146, issue #143). Five rounds,
+  and every round after the first found defects inside the previous round's fix — the row above.
+  What that row did not say is that the RECORD fixes fail at the same rate as the code fixes, and
+  they are the ones nobody re-runs, because a sentence does not look like something you execute.
+  Three in one loop:
+  - Round 3 was told an operator remedy was **followable by half**: `docs/RUNBOOK.md` §3-1 sent
+    an operator to run `reopen-phase` by hand without naming where its `--trigger-agent-run-id`
+    comes from. The fix named `failure_analysis.json#original_finding.failed_substep_agent_run_id`
+    — copied from the entry directly above, which is the AGENT-driven route — and on the
+    conductor-driven route nothing writes that key. Two round-4 reviewers measured it
+    independently: five reads in `orchestration_runtime.py` and zero writers; nine
+    `failure_analysis.json` in the local `workspace/`, zero carrying it. **A remedy that was half
+    followable became one that is not followable at all**, which is worse than the gap it replaced.
+  - The check round 3 wrote to hold it asserted the key's name occurred in
+    `orchestration_runtime.py`. It does — inside `_derive_resume_directive`, the CONSUMER the same
+    RUNBOOK sentence correctly says never fires for this reason. So the check **ratified** the
+    error. What closed it was driving the WRITER: build the artifact
+    `run_workflow._collect_failure_analysis` produces for that stop and resolve the documented
+    dotted path against it. A pin on a source substring cannot see this class; a pin on the
+    artifact can.
+  - Round 4's commit message reported fixing a splice defect "in the previous commit". An AST walk
+    over every commit on the branch showed no duplicated class member in any of them: the
+    duplication had been in the author's uncommitted working tree, mid-splice, and was written up
+    as a committed state without checking. The same commit then **created** the duplication it
+    claimed to delete — four test methods shadowed in one class, 66 `def test_` lines against 62
+    collected, with two of that round's own fixes in the dead half. Reproduced by a reviewer
+    inserting `self.fail("dead")` into a dead copy: green.
+  - A fourth, smaller: a mutant result was written into a commit message from a round-2
+    reviewer's report without re-running it, and round 3 re-ran it and found the opposite. The
+    standing rule "do not write someone else's measurement as your own"
+    (`atmofab-enforcement-change` rule 3) covers it and was broken anyway, in a COMMIT MESSAGE,
+    which is the site the rule most often gets skipped on because nothing there is red.
+  A fifth, hit while WRITING this entry, which is the reason the sign is worth its lines: the
+  citation fix below was verified by re-running `test_skill_citations` against an unstaged edit.
+  That check reads the INDEX (`git show :<path>`, deliberately — a tree whose index and worktree
+  disagree otherwise kills it with `FileNotFoundError` instead of reporting), so it was reading
+  the text that was still wrong and stayed red; staging it turned it green. **Re-running the
+  check is not enough if the check does not read what you edited** — ask what source it reads
+  before believing either colour.
+  Closure: the corrected sentence must pass the check the wrong one failed, and the check must
+  observe the thing the record describes rather than a string that co-occurs with it. The
+  repository-wide guard that came out of the third item is
+  `tools/tests/test_suite_environment_isolation.py::NoShadowedTestMethodTests` — a shadowed test
+  method is invisible from inside the suite: nothing goes red, the collected count silently drops,
+  and a `grep` lands on the dead half first.
 - **You have rewritten the same string three times** → the problem is not the rule but the prose
   citing it. Switch to the grep sweep
   (`.claude/skills/atmofab-enforcement-change/references/verification.md`). **Rewriting one statement


### PR DESCRIPTION
Follow-up to #146. Rules into `SKILL.md`, episodes into `references/`, per the split that keeps the skill files loadable. No production code changes.

## What issue #143's loop taught

**A new mid-loop sign in `atmofab-review-loop`: the fix was to a RECORD, so you verified it by reading.** A record fix carries the same defect rate as a code fix, and it is the sub-case of "a finding sits inside the previous round's fix" that gets skipped, because prose does not look like something you run. The criterion is that **the corrected sentence must pass the check the wrong one failed** — resolve the new key against the artifact, compute the new count, drive the function — and that a check written to hold a corrected record must observe what the record describes rather than a string that co-occurs with it.

#143 shipped three of these in three consecutive rounds. The sharpest replaced a half-followable operator remedy with an **unfollowable** one — a `failure_analysis.json` key nothing writes on that route — and pinned it by asserting the key's name occurred in a CONSUMER the same sentence says never fires there, so the check ratified the error.

The episode carries a fifth instance, hit while writing this branch: the citation fix below was "verified" against an unstaged edit, and `test_skill_citations` reads the INDEX (`git show :<path>`, deliberately — otherwise a tree whose index and worktree disagree kills it with `FileNotFoundError`), so it was reading the text that was still wrong. **Re-running a check is worth nothing if the check does not read what you edited.**

**`references/class-descent-log.md` gains PR #146** — the first loop to run to the cap. A round-by-round table of what each round's fix had introduced, plus two lessons the other histories did not carry:

- record fixes fail at the same rate as code fixes, and nobody re-runs them;
- **a pin can pin a CONTRADICTION.** Round 4 pinned both of the rubric's tie-break sentences positively, which was the right move against a digest-only guard — and one of them ordered a verdict the rubric's own `major` bullet forbids, so the literal pin froze the disagreement instead of surfacing it. Round 5 found it by RENDERING the leaf's prompt and reading the documents against each other, which no mutation sweep and no witness census can do.

It also records what the cap bought, since the budget section is where that cost belongs: round 5 was the loop's most productive round by severity, so stopping at the default of three would have shipped a shadowed-test-method defect (which had silently removed four of the branch's own checks), the tie-break contradiction, and an end anchor that made three documents' promise to the operator false.

**`atmofab-enforcement-change` rule 3-a gains a sixth trap: an EXEMPTION is a rule too, and it gets broken from both sides.** Deciding "routes" from "assigns" by pattern is §1's source-text surface asked of an exemption, and it loses the same way — one review round broke both directions at once, letting a hand-assignment through while refusing correct routing prose with a message that misnamed it. What closed it was an explicit allowlist of the exempt lines, compared as a set: a new mention of any wording is refused until someone reads it and adds an entry. Two follow-through traps are recorded with it — normalize the entry to the WHOLE line (a 60-character prefix let an assignment ride on an allowlisted line's tail), and derive the surface list from the code that decides it, because an emptiness set cannot self-test a surface that carries no exempt line.

That list's own header said "four traps" over five bullets. Corrected with the addition — it is this rule's enumeration trap turned on itself.

## The repository's only standing suite failure is fixed

`test_skill_citations` reads a backticked repo-relative path in a skill file as a POINTER and requires it to be tracked. The path in `references/mutation-testing.md`'s uncommitted-work episode names a probe file whose whole point is that it is **not** tracked. The rule is right and the citation was the defect, so the episode names the shape instead of a path a reader would try to open.

## Measurement

At `639cb4a`, primary checkout `/home/seiya/atmofab`, `python3 -m pytest tools/tests/ -q -p no:randomly`:

**5677 passed, 2908 subtests passed, 0 failed** — the first fully green run recorded here. Every measurement on #143's branch had to report around that baseline red; it is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxmqMTSmKeXvAMPyWFMKZJ
