### PR TITLE
skills: three traps issue #149 paid for, and three sonnet data points

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/references/verification.md
+++ b/.claude/skills/atmofab-enforcement-change/references/verification.md
@@ -251,6 +251,21 @@ done
 available (1 hidden fix can be enabled with the --unsafe-fixes option).` — in both cases the count
 is on the line above. Read the full output whenever the last lines differ.
 
+**A FILTER you write over the output is a third thing that can be empty, and an empty-vs-empty
+diff is green.** Issue #149 compared the two sides with
+`ruff check <f> | grep -E "^tools/" | sed … | uniq -c` and diffed the results: ruff's default
+output puts the path on a `-->` continuation line, not at the start of a line, so the filter
+selected NOTHING on either side and the diff printed clean. The branch shipped a commit message
+saying "histogram identical to the baseline" while it had in fact gone 13 -> 22 errors (four new
+`C408`, `RUF012` 3 -> 8), and a review round found it. Two rules, both one line:
+
+- **Assert the filter selected rows on at least one side before you compare.** `[ -s base.txt ]`,
+  or print the row counts beside the diff. A comparison of two empty sets is the same shape as
+  `assertEqual(rule(corpus), set())` for a rule that returns the empty set unconditionally.
+- **Ask for a STABLE format rather than parsing the human one**: `--output-format concise` is one
+  finding per line, `path:line:col: CODE message`, and it does not move between ruff versions the
+  way the default rendering does. `--statistics` is better still where a count is what you want.
+
 **If you want a NUMBER, ask ruff for it: `ruff check --statistics <f>`.** Do not write a counter
 for the occasion. On TODO:269 the count went into the ledger from `ruff check <f> | grep -c
 "^[A-Z][0-9]*"`, where `[0-9]*` matches zero digits, so `No fixes available` and its neighbours

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -340,6 +340,14 @@ nor resets the two-consecutive-clean-security-rounds condition.**
   mechanism level; handing over your mutation list breaks independence
 - **Include "build your own mutants that delete one mechanism at a time, run them, and report
   survivors"**
+- **Say "mutate the SUBJECT, not the test", in the launch prompt.** Round 0's rules already state
+  that reverting an added test hunk deletes an assertion and survives by construction, but that is
+  written for the script and reviewers do not read it: on issue #149 a security axis reported a
+  whole sweep as vacuous on the strength of replacing the test's own `for line in CONSTANT:` with
+  `for line in []:` — which of course stayed green. A second axis mutated the CONSTANT in the
+  production module the same round and it was red. **A vacuity claim is only worth the mutation
+  behind it**, so ask for the mutation to be named with the claim, and re-run any that mutated the
+  test rather than the thing the test is about
 - **Spell out the process and shared-resource rules**: no unscoped `pkill`; **create only waits
   whose exit condition can be satisfied, and no background polling**; `/tmp` is a shared tmpfs,
   delete the trees you create. Four accidents happened for real, each spilling into other
@@ -382,6 +390,17 @@ nor resets the two-consecutive-clean-security-rounds condition.**
 - **If the reported HEAD is a hash you do not recognize, find out what commit it is first** —
   the user or another session can commit to the same branch. That is concurrency, not staleness:
   read it and **judge whether it collides with your scope**
+- **When a round's reviewers cannot LAUNCH, the round is not clean and it is not spent.** A
+  subagent that dies to a transport error before its first tool call has reviewed nothing; check
+  the transcript for tool calls rather than reading the failure as a result. Retry once, and if
+  the up-model stays unavailable there are two moves and they are not equal: **convert the axis
+  into an enumerated checklist and delegate it** (that is verifiable work, so the sonnet line
+  applies), or **run it yourself and lose the independence**. Say which you did, in the commit and
+  to the user — an axis run by the author advances neither stopping condition. On issue #149 SEVEN
+  consecutive up-model launches died to HTTP 500 / 529 across two rounds, and the round that
+  recovered did so as a checklist of seventeen named mutations plus five over-refusal probes; what
+  that CANNOT tell you is whether an open-ended attacker would have found an eighteenth, because
+  the list was the author's
 - **Hand over the premises in one paragraph** (`AGENTS.md` §"Development premises" is canonical;
   hand over this short form): "a single-operator research workflow platform. What is defended
   against is a **`leaf shortcut`** — an `LLM` leaf is not malicious and takes shortcuts, so
@@ -494,7 +513,7 @@ same run — it is a reason to re-run the positive verdicts your change actually
 
 ## Delegate verifiable work to sonnet
 
-**Operational conclusion (10 data points; the confound resolved in PR #72 by giving both models
+**Operational conclusion (13 data points; the confound resolved in PR #72 by giving both models
 the same checklist, the axis run as delegated in PR #88): sonnet ⊂ opus, with real misses.** Move **the mechanical-recomputation axis**
 permanently to sonnet and keep judgment on the up-model. Costs came out roughly equal, so "it is
 cheap, so run more" does not hold — **use it only to free up a slot**. Run one via `Agent` with
@@ -523,9 +542,11 @@ numbers" does not give "it matches on parser semantics". **Measure per axis.**
 
 **Tell it to report claims it cannot locate rather than accounting for them** — refusing a false
 premise I had put in its prompt is the most valuable thing this axis has done — and the most
-reproducible, having now happened in five of the ten data points (5, twice on PR #107, on issue #142, and on
-PR #116, where it reported that the ten-item mutant list a commit message referenced was recorded
-nowhere it could find — true, and the thing I would least have checked myself).
+reproducible, having now happened in six of the thirteen data points (5, twice on PR #107, on issue
+#142, on PR #116 — where it reported that the ten-item mutant list a commit message referenced was
+recorded nowhere it could find, true, and the thing I would least have checked myself — and on
+issue #149, where it refused a checklist item of mine asserting a sweep was vacuous, by mutating
+the subject rather than the test and getting RED).
 **This stays an experiment**: collect real/total findings, elapsed time and the overlap count,
 add a data point each time, and delete this section if it stops paying. How to read overlap, how
 not to confound the comparison, and why the reverse (opus reviewing sonnet's implementation) is

--- a/.claude/skills/atmofab-review-loop/references/mutation-testing.md
+++ b/.claude/skills/atmofab-review-loop/references/mutation-testing.md
@@ -40,6 +40,33 @@ non-observing command cannot pass). Handwriting keeps neither for free. When you
 reproduce both: run the baseline, and compare its COUNT — not its exit status — against what you
 expect, before you believe a single mutant.
 
+## A reviewer mutated the TEST and reported the sweep vacuous (issue #149, 2026-09-03)
+
+The branch added a sweep that scans, among other host literals, `tools/pure_leaf.py`'s
+`PURE_SYSTEM_PROMPT` — the system prompt every pure leaf receives outside its launch prompt — for
+a hand-assigned severity. The constant carries none today, so the block is a growth bound.
+
+Round 1's security axis reported it as **vacuous, unpinned dead machinery**, and named its
+mutation: replace the sweep's own `for line in PURE_SYSTEM_PROMPT.splitlines():` with
+`for line in []:`. Green, as it must be — that edit deletes the loop that produces the finding,
+which is an assertion, and **an assertion you delete cannot fail**. It is the same shape as
+`--include-tests` reverting an ADDED test hunk, written down elsewhere in this file for the
+script and never handed to a reviewer.
+
+The same round's correctness axis mutated the SUBJECT instead — it appended
+``Record `issue_severity=major`.`` to the constant in `tools/pure_leaf.py` — and the sweep was
+RED. The author reproduced the second independently before rejecting the first. Two axes, one
+question, opposite answers, and the disagreement was entirely in the choice of mutant.
+
+**What it cost**: nothing, because a second axis happened to ask the same question properly. Had
+only the first run, the honest response to "this block observes nothing" is to delete the block —
+and the branch would have shipped having removed a real growth bound on a leaf-read host literal,
+justified by a measurement of the wrong thing. That is `atmofab-enforcement-change` rule 1-b's
+failure mode arriving through a reviewer rather than through the author.
+
+**The rule** (SKILL.md, "Running a round"): tell reviewers to mutate the subject, ask for the
+mutation to be named beside any vacuity claim, and re-run the ones that mutated a test.
+
 ## The harness's own scratch paths reddened the baseline (TODO:414, 2026-08-21)
 
 Two of the script's defaults were themselves inputs to the suite under test, and together they

--- a/.claude/skills/atmofab-review-loop/references/round-conduct.md
+++ b/.claude/skills/atmofab-review-loop/references/round-conduct.md
@@ -183,6 +183,37 @@ alone (`origin/main...HEAD` equals stage B's diff). That is the shape the stagin
     keeps working has NOT waited, and the loop is still out there. On PR #81 I noticed
     that mid-session, said so, and still left two behind for the user to find
 
+## When the round's reviewers cannot launch at all (issue #149, 2026-09-03)
+
+Round 2 of issue #149 was launched as the usual two up-model axes. Both died to HTTP 500 / 529.
+Relaunched, both died again; two further attempts at the security axis died too, the second
+carrying an explicit "if you hit a transient error, continue from where you are" clause, and so
+did round 3's blank-slate launch. **Seven consecutive up-model launches across two rounds, and the
+transcripts show no tool calls at all** — the failure lands before the agent's first command, so
+nothing was reviewed and nothing was learned. Round 1's three launches, hours earlier, had all
+succeeded, so this is a window rather than a property of the prompt.
+
+Three things this makes clear, none of which was written down:
+
+- **Read the transcript, not the status.** A launch that failed and a launch that returned nothing
+  look the same in a summary line. The distinction that matters is whether any tool ran; if none
+  did, the round is not spent, and relaunching is not a second round.
+- **The recovery is not free, and the two options differ in what they buy.** Converting the axis
+  into an ENUMERATED CHECKLIST of named mutations makes it verifiable work, which is exactly the
+  line the sonnet delegation is drawn on, so it can be delegated and it will be run properly. What
+  it cannot do is find the attack you did not think of: the list is the author's, so the round
+  measures the author's imagination with someone else's hands. Running the axis YOURSELF is worse
+  on independence and better on nothing.
+- **Say which happened.** Round 2 shipped with its security axis run by the author, stated in the
+  commit message and in the PR body as advancing neither stopping condition. Round 3 recovered a
+  delegated blank-slate attack axis (seventeen enumerated mutations plus five over-refusal probes,
+  no holes) and a disclosure axis (one real record defect, found by nothing else). Writing "round 2 was clean" would have
+  been false in a way no later reader could detect.
+
+The budget question this leaves open: a round that could not launch is not a round, so it does not
+count against round 0 plus three — but the wall-clock and the token cost were spent anyway, and
+the decision to keep paying for retries belongs to the user once the second one fails.
+
 ## Over-refusal: the five countermeasures and where each came from
 
 - **For a change that adds checking machinery, include "construct legitimate work that this check

--- a/.claude/skills/atmofab-review-loop/references/sonnet-delegation.md
+++ b/.claude/skills/atmofab-review-loop/references/sonnet-delegation.md
@@ -1,6 +1,63 @@
 # Delegating verifiable review work to sonnet: the experiment log
 
-Nine data points. SKILL.md carries the operational conclusion; this is the evidence, newest first.
+Twelve runs narrated here, newest first. SKILL.md counts THIRTEEN, and the extra one is not a
+miscount: PR #116's run is cited there (it reported that a ten-item mutant list a commit message
+referenced was recorded nowhere it could find) and was never written up in this file. Numbering
+skips 10 for that reason. SKILL.md carries the operational conclusion; this is the evidence.
+
+## Data points 11-13 (issue #149 / PR #151, rounds 2 and 3) — three runs, and the first time the axis was load-bearing
+
+**The circumstance is the point.** Five consecutive up-model launches died to HTTP 500 / 529
+before their first tool call (`references/round-conduct.md`), so for two rounds sonnet was not an
+added axis in parallel with opus — it was the only reviewer that ran. That makes these three runs
+evidence about a question the previous nine could not answer: what does the delegation cover when
+it is carrying the round rather than supplementing it?
+
+**11. Census + doc-truth (round 2).** Re-measured every numeric claim in four commit messages and
+the docstrings and matched all of them (74/51, 1303/378, 5685/2949, 31 configurations, the ruff
+histogram at both revisions, 3031/1602 for a stub measurement in a pristine base worktree).
+Reproduced six of twelve stated controls, deliberately including both a RED claim and a green one,
+all six matching. Verified both exemption reasons in the new machinery by mutation. Established
+that a `sys.settrace`-based test measures under `pytest` and under `python3 -m unittest` and leaks
+no tracer. **0 findings, and it named the six controls and the several census rows it did not
+run** rather than accounting for them — the instruction that keeps paying.
+Its one substantive contribution was a REFUSAL, and it is data point five of the same kind:
+handed a checklist item asserting a sweep was vacuous, it mutated the SUBJECT instead of the test
+and reported RED, contradicting the up-model security axis that had reported the opposite
+(`references/mutation-testing.md`).
+
+**12. Attack checklist (round 3, blank-slate).** The security-bypass axis, converted from an
+open-ended brief into seventeen NAMED mutations across three mechanisms plus five over-refusal
+probes, each with a stated expected verdict. Executed all of them; every severity-injection
+attempt in the first three parts was correctly RED, it
+enumerated one helper's field coverage against the renderer's call sites and reported no gap, and
+it correctly classified two results as over-refusals rather than holes plus one as borderline. It
+also checked, unprompted, whether a regex matched a probe string it had been told to use — and
+reported that it did not, which changed why one row was red. **0 holes, 2 over-refusals, 0 false
+positives.**
+**What this run does NOT establish**: the items were the author's. A checklist measures
+the author's imagination with someone else's hands, and that is the whole of the difference
+between this and the axis it replaced.
+
+**13. Disclosure (round 3).** Two jobs — verify every claim in the commit messages at HEAD, and
+read the branch as the next maintainer. 602 s, 61 tool calls (the other two runs' figures were not
+captured). **1 finding, real, found by no other axis**: a sentence in a fix commit's message, and
+its twin in a docstring, spliced two configurations' measurements — "`generate.verify` claimed 42
+lines of which 41 rendered from nothing, one of them the severity-bearing line". It rebuilt both
+configurations at the parent commit and showed 42/41 belongs to `generate.generate`, while the
+line is `generate.verify`'s at 36/35, so no single configuration has both properties. It then
+answered the deletion question properly — enumerated the three assertions the branch removed,
+named each one's successor, red-then-red tested the pairing that mattered, and **reported the one
+residual it could not clear** (a defect shape the removed textual-diff check might have caught
+that the membership check replacing it does not).
+
+**Reading.** The delegation held on all three, including the disclosure brief, which is the least
+mechanical thing it has been given and which produced the round's only defect. What did NOT get
+tested is the line SKILL.md actually draws: the open-ended security brief was converted to a
+checklist rather than delegated as-is, so **"sonnet carried the security axis" is not what
+happened and must not be read out of this**. What happened is that three checklist-shaped axes
+carried a round, and the one finding they produced was a false record — the same descriptive class
+every earlier data point has returned.
 
 ## Data point 9 (issue #142 / PR #144, round 1) — three findings, all real, one overlap
 


### PR DESCRIPTION
Follow-up to #151 (issue #149). Dev-skill prose only — five files under `.claude/skills/`, no production code, no test logic, nothing a workflow leaf reads.

## Why these three and not others

`atmofab-enforcement-change` §7 and `atmofab-review-loop`'s closing section both say to judge at the end of the work whether the skills went stale or a gap showed, and to **tell the user rather than rewrite silently**. Issue #149's loop produced three traps that cost real rounds and were written nowhere, plus three data points a section explicitly asks to be collected. The rules go in `SKILL.md`, the episodes in `references/`, which is the split that keeps those files loadable.

## The three rules

**1. A filter you write over a tool's output is a third thing that can be empty** — `atmofab-enforcement-change/references/verification.md`, in the ruff-diff recipe it already carries.

The branch's ruff check was `ruff check <f> | grep -E "^tools/" | sed … | uniq -c`, run on both sides and diffed. ruff's default rendering puts the path on a `-->` continuation line, so the filter selected **nothing on either side** and the diff printed clean. The commit message said "histogram identical to the baseline"; it had gone 13 → 22 errors. Measured again while writing the rule, at `de53c04`: the grep selects 0 rows, the first location line is `--> <path>:1:1`, and the histogram there is 4 `C408` and 8 `RUF012` on top of the baseline's 13.

Two one-line rules: assert the filter selected rows on at least one side before comparing, and ask for `--output-format concise` instead of parsing the human rendering. The section already told you to prefer `--statistics` for a count; it did not cover the case where you build your own.

**2. Mutate the SUBJECT, not the test** — `atmofab-review-loop/SKILL.md` §Running a round, episode in `references/mutation-testing.md`.

Round 1's security axis reported a sweep as vacuous, naming its mutation: replace the sweep's own `for line in PURE_SYSTEM_PROMPT.splitlines():` with `for line in []:`. Green, necessarily — that deletes the assertion. The same round's correctness axis mutated the constant in `tools/pure_leaf.py` and it was red. Two axes, one question, opposite answers, and the whole disagreement was the choice of mutant. Had only the first run, the honest response to "this observes nothing" is to delete the block, and the branch would have removed a real growth bound on a leaf-read host literal on the strength of a measurement of the wrong thing.

The fact was already in `references/mutation-testing.md`, written for `mutation_check.py` and never handed to a reviewer. Now it is a launch-prompt clause, with "name the mutation beside the vacuity claim" so the check is cheap.

**3. A round whose reviewers cannot LAUNCH is not clean and is not spent** — `atmofab-review-loop/SKILL.md` §Running a round, episode in `references/round-conduct.md`.

Seven consecutive up-model launches across two rounds died to HTTP 500 / 529 **before their first tool call**; round 1's three launches hours earlier had all succeeded, so it is a window, not a property of the prompt. A launch that failed and a launch that found nothing look identical in a summary line, and the distinction is whether any tool ran.

The recovery has two moves and they are not equal: converting the axis into an enumerated checklist makes it verifiable work, so it can be delegated and will be run properly — but the list is the author's, so it measures the author's imagination with someone else's hands; running it yourself is worse on independence and better on nothing. Either way, say which.

## The data points

`references/sonnet-delegation.md` gains 11-13 — this branch's census/doc-truth, attack-checklist and disclosure runs — which the section's own standing instruction asks for. The entry states plainly what they do **not** establish: the open-ended security brief was converted to a checklist rather than delegated as-is, so "sonnet carried the security axis" is not what happened.

It also fixes a real inconsistency: the file said "Nine data points" while `SKILL.md` said ten. Not a miscount — PR #116's run is cited in `SKILL.md` and was never written up in the log. Numbering now skips 10 for that reason; the file says twelve narrated, `SKILL.md` says thirteen. The premise-refusal tally goes 5/10 → 6/13.

## Corrections carried here

`496ffd6`'s message and #151's body said round 3 ran "19 attacks". Recounted from the axis's own result table — 23 rows, one an enumeration rather than a mutation — it is **17 severity-injection mutations plus 5 over-refusal probes**. Verdicts unchanged. #151's body also said "19 of the defects fixed", a number with no derivation; recounted from the commit messages it is **six code defects and six false records**. Both are fixed in #151's body, which is editable; the merged commit messages are not, so the correction is stated.

That makes eight false records this line of work has produced and corrected, all eight in prose nothing runs — which is itself the argument for rules 1 and 2.

## Verification

- `python3 -m pytest tools/tests/test_skill_citations.py -q -p no:randomly` → 34 passed, 10 subtests. That is the only check that reads these files; it verifies every backticked repository path they cite is tracked, and nothing verifies the claims.
- Every measurement quoted in the new prose was re-run while writing it, at the commit it names.
- No review rounds. `atmofab-review-loop` says text only a maintainer reads gets no round of its own; a defect here is corrected in the commit that notices it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxmqMTSmKeXvAMPyWFMKZJ
