### PR TITLE
skills: the four traps issue #153 paid for

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -123,7 +123,13 @@ execute it**: numbers, rule ids, compiler diagnostics and "X catches this" are a
 claims, and **write a range when the number varies**; and **the flip side of rule 3 is that prose you newly write in the same commit is
 unverified until you run it** (L128 got four freshly written measurements or citations wrong
 inside the fix itself). **Do not write someone else's measurement as your own** — cite the source
-explicitly, or re-measure before writing. **Keep a list of every place you wrote a number and
+explicitly, or re-measure before writing. **The place this fires that you will not expect is a
+CORRECTION**: a reviewer's finding arrives already carrying evidence, so it feels verified before you
+write it, and issue #153 wrote a reviewer's HEAD-measured count into a corrections bullet as the count
+"when that commit landed" — replacing a correct figure with a wrong one, one item after condemning
+that exact substitution. **Re-measure at the commit you are about to NAME, not at HEAD**
+(`atmofab-review-loop`'s "the fix was to a RECORD" sign owns the procedure).
+**Keep a list of every place you wrote a number and
 re-measure them together at the end**; a commit message cannot be fixed afterwards, so either
 mark the number as measured at a point or rewrite it in the final round.
 

--- a/.claude/skills/atmofab-enforcement-change/references/failure-routing.md
+++ b/.claude/skills/atmofab-enforcement-change/references/failure-routing.md
@@ -158,3 +158,38 @@ cannot converge in principle**, handed back to the leaf (flagged two rounds runn
   indistinguishable from a true negative, so the leaf reports absence and stops. When a remedy
   is a conjunction, say so, and say what doing one half produces
 
+
+## An evaluator whose contract is a VERDICT, and what a raise from it costs (2026-09-04, issue #153)
+
+A new branch of §The decision, and it is not "whose fault is it" — it is "what shape may the answer
+take". Some functions inside enforcement machinery are not gates that refuse; they are **evaluators
+that must always produce a verdict**, because the caller has no handler and the verdict is one input
+among several. This repository's readiness comparisons are the case: `_verify_dep_stage_detail` and
+the freshness functions under it are documented as pure and never raising.
+
+**What a raise from one of those costs is not a fail-closed, it is a lost run.** The closure driver
+(`run_workflow._run_with_dependency_closure`) calls readiness inside its per-node loop with no
+`except`, so an exception there aborts the whole `--with-deps` closure rather than reporting one node
+not-ready. An operator mid-closure loses every node still to come, and the `--resume` they reach for
+resolves nothing because the input that raised is unchanged. Compare a gate: a gate that raises is
+routed to a transport `fail_closed` by design, which is a correct and recoverable outcome. **The same
+exception, one layer over, is the difference between "this node is not ready" and "this run is
+over".**
+
+**Three things follow.**
+
+- **Decide which kind you are writing, and say so in the docstring.** "Pure and NEVER raises" is a
+  contract a later reader will rely on when adding a caller, and it is the sentence that makes the
+  guards below non-negotiable rather than defensive clutter.
+- **The contract is only as good as the operations it covers.** Issue #153 shipped three such
+  evaluators and all three could raise, on the same shape: a host-authored artifact that is not
+  schema-checked, read into an operation that raises on the wrong type (`for … in` on a non-iterable,
+  `list.sort` over mixed types). Enumerate the raising operations, not the input types.
+- **A guard added for this reason needs a witness that reaches the raising operation**, and the
+  family it is tested with has to straddle the type test — three review rounds went on that one
+  point (`atmofab-review-loop/references/mutation-testing.md` §"Issue #153").
+
+**Scope, stated because the premises govern it.** None of this was a `leaf shortcut`: the artifacts
+in question are host-authored and leaf-non-writable, so no leaf gains anything by malforming one. It
+is an availability and reproducibility class — the "loss of reproducibility" fix category in
+`atmofab-review-loop` — which is why it is in scope at all despite no leaf gain.

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -158,6 +158,14 @@ when a rule does not obviously apply:
   is to go and write the test you already wrote. **Commit the tests before the sweep**, and when
   a survivor surprises you, revert that one hunk by hand against your working tree before
   believing it (`references/mutation-testing.md`)
+- **Hand-revert a KILL that surprises you, not only a survivor.** The rule above doubts survivors;
+  the reverse happened on issue #153. A re-run reported EVERY hunk killed, including one whose whole
+  content was a widened type annotation and a deleted unused local — no behaviour to pin — and a
+  hand revert of that same hunk was **green**. Cause unidentified; the runs differed in `--paths`
+  and `--test-cmd`, baseline green in both. **The verdict you keep is the one you can reproduce by
+  hand**; report an unreproducible kill as such rather than banking it, because "every hunk is
+  pinned" is what a reader will quote back. **The tell is a kill on a hunk you cannot name a
+  behaviour for**
 - **If the change's mechanism lives inside a test file, hunk mutation does not apply** — "nothing
   to check" with a correct base is **not applicable, not a pass**, and `--include-tests` does not
   rescue it (reverting an ADDED test hunk deletes an assertion, so it always survives; a hunk
@@ -230,6 +238,15 @@ when a rule does not obviously apply:
   - **one test per occurrence of a rule, not per rule** — and **the sharpest trigger is a TWIN**:
     when a change touches one of a matched pair, list the pair, list your witnesses, compare the
     two lists before handing over
+  - **when the guard tests a TYPE, the family must STRADDLE that type test, and assert that it
+    does** — the type case of the family sign below, and its own line because it recurred three
+    times in one branch after two diagnoses (issue #153). A family of malformed values assembled by
+    imagination comes out malformed the SAME WAY: ten members, every one iterable, cannot kill an
+    `isinstance(x, list)` guard. **More members do not close it; a self-test in the test body does**
+    — loop the members through `iter()` and require both a `TypeError` and a success, because that
+    is what a later member added on one side only turns red. **Trigger**: any `isinstance` /
+    `hasattr` in a guard whose purpose is to not raise — name the operation that would raise
+    (`for … in`, `sort`, `len`, `[k]`) and ask which member reaches it
   - **a hand-built fixture can test a shape that does not exist** — check the construct against
     the real corpus before writing the witness
   - **for stateful code, match the fixture to the lifetime of the state**, and always include a
@@ -513,7 +530,7 @@ same run — it is a reason to re-run the positive verdicts your change actually
 
 ## Delegate verifiable work to sonnet
 
-**Operational conclusion (13 data points; the confound resolved in PR #72 by giving both models
+**Operational conclusion (14 data points; the confound resolved in PR #72 by giving both models
 the same checklist, the axis run as delegated in PR #88): sonnet ⊂ opus, with real misses.** Move **the mechanical-recomputation axis**
 permanently to sonnet and keep judgment on the up-model. Costs came out roughly equal, so "it is
 cheap, so run more" does not hold — **use it only to free up a slot**. Run one via `Agent` with
@@ -542,11 +559,17 @@ numbers" does not give "it matches on parser semantics". **Measure per axis.**
 
 **Tell it to report claims it cannot locate rather than accounting for them** — refusing a false
 premise I had put in its prompt is the most valuable thing this axis has done — and the most
-reproducible, having now happened in six of the thirteen data points (5, twice on PR #107, on issue
-#142, on PR #116 — where it reported that the ten-item mutant list a commit message referenced was
-recorded nowhere it could find, true, and the thing I would least have checked myself — and on
+reproducible, having now happened in seven of the fourteen data points (5, twice on PR #107, on
+issue #142, on PR #116 — where it reported that the ten-item mutant list a commit message referenced
+was recorded nowhere it could find, true, and the thing I would least have checked myself — on
 issue #149, where it refused a checklist item of mine asserting a sweep was vacuous, by mutating
-the subject rather than the test and getting RED).
+the subject rather than the test and getting RED, and on issue #153, where a checklist item of mine
+attributed a "pure and NEVER raises" docstring to the wrong function: it reported the premise as not
+locatable, went and checked the functions that DO make that claim, and found one that could raise).
+**That last one is the shape to design the checklist for.** The item was wrong about WHERE the claim
+lived, and a reviewer that answered the question as asked would have returned "not applicable"; what
+made it pay is the instruction to report an unlocatable claim, which turned a defective checklist
+item into the round's live defect.
 **This stays an experiment**: collect real/total findings, elapsed time and the overlap count,
 add a data point each time, and delete this section if it stops paying. How to read overlap, how
 not to confound the comparison, and why the reverse (opus reviewing sonnet's implementation) is
@@ -788,9 +811,11 @@ it). It has **never been achieved in any recorded loop**. **Run assuming you wil
 not add rounds waiting for it.
 
 **Do not make "Codex is clean" a stopping condition** — as a condition it becomes a motive to
-relaunch a Codex you have no budget for. Clean came back once (PR #67) and the same round's two
-subagents produced unwitnessed mechanisms, over-refusals and an abandoned mirror; on TODO:269
-Codex was clean in round 2 and round 3 found a mechanism with no behavioural witness at all.
+relaunch a Codex you have no budget for. Clean has come back twice, and BOTH times the same round's
+subagent work was not: on PR #67 two subagents produced unwitnessed mechanisms, over-refusals and an
+abandoned mirror, and on issue #153 the blank-slate subagent sharing that round returned four
+findings, one of them a guard whose test family could not fail. On TODO:269 Codex was clean in round
+2 and round 3 found a mechanism with no behavioural witness at all.
 
 **Practical proxies for "the remainder is bounded"**, both of which must hold:
 
@@ -904,7 +929,17 @@ that tells you how it closed.
   re-running it. **And the check written to hold a corrected record must observe the thing the
   record describes**: the first of those was pinned by asserting the key's name occurred in a
   module — it did, in a CONSUMER the same sentence says never runs — so the check ratified the
-  error (`references/signs-episodes.md`)
+  error (`references/signs-episodes.md`).
+  **The sharpest form is a correction you make ON A REVIEWER'S MEASUREMENT**, where the rule you
+  already know does not fire: `atmofab-enforcement-change` rule 3 says not to write someone else's
+  measurement as your own, and issue #153 broke it there — replacing a correct figure with a wrong
+  one, one item after condemning that substitution. **A reviewer's finding arrives already carrying
+  evidence, so the correction feels verified before you write it**, and a corrections entry is the
+  one place a reader will not re-check. **Re-measure at the commit you are about to NAME, not at
+  HEAD**; for a per-commit figure take the whole series in one worktree-per-revision loop, so the
+  attribution is visible rather than inferred. **Do not delete a wrong correction — record that it
+  was wrong**, or nobody can tell an audited corrections bullet from an unaudited one
+  (`references/measurement-records.md`)
 - **You have rewritten the same string three times** → the problem is not the rule but the prose
   citing it. Switch to the grep sweep
   (`.claude/skills/atmofab-enforcement-change/references/verification.md`). **Rewriting one

--- a/.claude/skills/atmofab-review-loop/references/class-descent-log.md
+++ b/.claude/skills/atmofab-review-loop/references/class-descent-log.md
@@ -319,6 +319,58 @@ descent not achieved, blank-slate zero-functional-defects not achieved twice. Th
 census is explicitly not closed — an independent census found 24 of 40 mutants surviving in round
 4, and the author's own 12-mutant sweep afterwards is a statement about those 12.
 
+## PR #154 / issue #153 — the class descended all the way to prose, and the loop still stopped short
+
+Content-granular closure bindings: a dependency regenerated under an unchanged `spec_version` no
+longer leaves its consumers recorded as READY. Round 0 plus **three** rounds — the default budget —
+two judgment axes plus a sonnet mechanical axis in rounds 1 and 2, the Codex launch spent in round 2,
+and round 3 given entirely to the disclosure axis (both agents, per SKILL.md's "before stopping
+rather than as an extra round after deciding to stop").
+
+**The descent, and it is the cleanest recorded here: original design -> my fix -> my witnesses -> my
+records -> my prose.**
+
+| round | findings | class |
+|---|---|---|
+| 0 | 1 live code defect in my own fix | hole in the fix |
+| 1 | 1 live code defect (same shape), 3 coverage gaps, 1 dead function with a false docstring, 1 trust-boundary wording, 5 wrong figures | fix + witnesses + records |
+| 2 | 0 code defects. 2 test families that could not fail, 1 record wording, and my own round-1 correction wrong in the shape it condemned | witnesses + records |
+| 3 | 0 code defects, 0 functional. 1 operator-facing mislabel, 3 record corrections | prose + records |
+
+**No fail-open in any round, and no finding in pre-existing machinery.** Every finding was in
+something the branch itself added. That is a different history from PR #146's, where the class did
+not descend at all.
+
+**What the round-3 disclosure axis bought, and nothing else could have.** Its brief included "what
+CHECK went with what was deleted", and it applied eleven defects the touched checks used to catch at
+BOTH revisions. Ten red-then-red; the eleventh ran the safe way — `origin/main`'s unsafe-token guard
+was UNTESTED there and is pinned at HEAD. **No red-then-green**, which is the finding that instrument
+exists to produce. It also surfaced the one guarantee the branch gives up (the replaced inline loop
+crashed on a malformed sidecar for a node declaring no dependencies; the replacement returns `[]`),
+which went into the design record as a named trade rather than staying in a round report. The other
+disclosure agent re-executed every executable claim in eight commit messages and found exactly one
+wrong — a claim about the LOOP's own regularity, which is worth noting: the false statement was not
+about the code but about the review process, offered as evidence for one of this skill's heuristics.
+
+**Why this loop stopped at the default instead of pushing to the cap.** The remainder is bounded on
+the sweep proxy: three reviewers built their own sweeps and reported 22, 26 and 11 mutants
+respectively (their counts, from their reports — I did not rebuild the lists). Three survivors came
+out of the first two, and those I did reproduce and close by hand: the launch-gate demotion threshold
+(`>= 2` -> `>= 3`, now RED with `AssertionError: 2 != 1`), the `isinstance(bindings, list)` clause, and
+the `topo_level` bool clause. So "fully killed" is a claim about the survivors, which I measured, and
+not about the 59 mutants, which I did not re-run. But the change ADDS checking machinery, and SKILL.md's proxy there is a blank-slate review
+with zero functional defects for **two consecutive** rounds. Only round 2 supplies one; round 3 was
+the disclosure round, which does not count toward it. So the honest statement is "stopped at the
+default budget with one of two proxy rounds", not convergence, and the PR body says so. Nothing in
+scope was left open.
+
+**The reading to carry forward.** A loop whose findings walk from code to witnesses to records to
+prose is descending correctly, and the temptation at the bottom is to call it converged because the
+last round found "only prose". Both of round 3's findings were in the first of SKILL.md's two prose
+categories — text an operator ACTS ON (`stale=` printed for a node that was never built) and a false
+record about the branch — so neither belonged in the bounded remainder. **The descent tells you the
+loop is working; it does not tell you it is finished, and the two proxies are what decide that.**
+
 ## PR #146 / issue #143 — the first loop to run to the cap, and what the cap bought
 
 A rubric for choosing a `verify` verdict's `issue_severity`, defined once in a phase document and

--- a/.claude/skills/atmofab-review-loop/references/codex-episodes.md
+++ b/.claude/skills/atmofab-review-loop/references/codex-episodes.md
@@ -113,6 +113,21 @@ for "Codex is clean" never ends the loop**. Drop it from the superior condition 
 "does it exist in the real corpus". For the same reason the second and third launches waste the
 budget: replace them with blank-slate subagents.
 
+**And when it IS clean, the round is not.** Clean has now come back twice, and both times the
+subagent sharing that round was not clean. Issue #153: the round-2 launch (native `review`,
+`--base origin/main --scope branch`, no stall, exit 0) returned "The changes consistently record and
+validate dependency source bindings across both readiness evaluators and the closure driver. No
+actionable correctness regressions were identified in the changed code." The blank-slate subagent in
+the same round returned four findings — including a guard whose test family could not fail, and a
+corrections bullet that had committed the error it condemned. **Two readings, and the second is the
+useful one**: (a) Codex was right about what it was asked, which was correctness of the changed code,
+and every one of the four findings was about a WITNESS or a RECORD rather than about production
+behaviour; (b) that is exactly the class Codex does not look for, so a clean pass bounds a narrower
+question than the round does. Note also that this branch ADDS checking machinery, where the paragraph
+above predicts Codex almost always finds one more construct — it did not, so the prediction is a
+tendency and not a rule. Cheap to record, and it stops "Codex was clean" from being quoted as
+evidence about the round.
+
 ## Content filter drops
 
 L128 launched four times and **three were interrupted** (security-flavoured vocabulary plus

--- a/.claude/skills/atmofab-review-loop/references/measurement-records.md
+++ b/.claude/skills/atmofab-review-loop/references/measurement-records.md
@@ -82,3 +82,45 @@ N+1 between edit N and its write**. The general form is the same one the placeho
 teaches: the remedy for hand-typed numbers has its own failure mode, and so does the remedy for
 hand-edited prose. Verify the write, not the intent.
 
+
+## Issue #153 — a corrections bullet that committed the error it was condemning
+
+Round 1's two axes independently re-measured every number the branch recorded and found five wrong.
+The fix commit rewrote them as historical records naming the commit and the command, and added a
+`TODO.md` sub-bullet titled "Corrections to this branch's OWN records, because a wrong baseline makes
+the next delta wrong". Its three items:
+
+1. the three-suite baseline at `59fb060` was recorded as 2314 and is 2336 — 2314 was my own count
+   taken mid-implementation with 22 tests failing, written in as if it were the baseline;
+2. the full-tree baseline was **cited rather than measured** — "5683 / 2949 at `59fb060`, the figure
+   recorded by issue #149's own entry above", where that entry records 5683 at `de53c04`, nine
+   commits earlier; the measured figure is 5685;
+3. a `ruff` I001 delta "was 227 when that commit landed".
+
+**Item 3 was wrong, and wrong in item 2's shape.** Measured per revision, one fresh detached worktree
+each: `59fb060` 220, `17b7a8f` 226, **`8c77ad4` 226**, `bcaa99b` 227, `b134d68` 227, `aed433d` 229.
+The original figure (220 → 226) was correct at the commit carrying it; 227 is `bcaa99b`'s; the
+correction attributed a later commit's figure to `8c77ad4`. So the bullet performed the
+wrong-attribution error one item after condemning it, and replaced a correct number with a wrong one.
+
+**The cause is nameable and it is not carelessness about arithmetic.** Two round-1 reviewers reported
+227, both measured at branch HEAD. `atmofab-enforcement-change` rule 3 says, in these words, not to
+write someone else's measurement as your own — cite it or re-measure. I had read that rule the same
+session. What defeated it: **a reviewer's finding arrives already carrying evidence.** The number came
+with a table and a command, so the correction felt verified before it was written, and the one thing
+neither reviewer had done was measure at the commit the sentence would name.
+
+**Two rules that follow, both cheap:**
+
+- **Re-measure at the commit you are about to NAME, not at HEAD.** When the finding is about a
+  per-commit figure, take the whole series in one worktree-per-revision loop; the attribution is then
+  visible instead of inferred, and the loop is six lines.
+- **Record that a correction was wrong rather than deleting it.** Round 3 verified the branch's
+  records and the third item's own correction is now in the ledger with the per-revision table. A
+  corrections bullet that silently loses an entry is worse than one carrying its own history: the
+  next reader cannot tell an audited bullet from an unaudited one.
+
+**What the form change did buy.** Round 3 re-executed every other executable claim in eight commit
+messages — several to the exact traceback line, assertion text and per-file digit — and found nothing
+else wrong. The rewrite into "historical record naming the commit and the command" held; the one
+failure was the entry written from someone else's measurement.

--- a/.claude/skills/atmofab-review-loop/references/mutation-testing.md
+++ b/.claude/skills/atmofab-review-loop/references/mutation-testing.md
@@ -518,3 +518,50 @@ a mutant killed since two rounds earlier came back green. **An outer state of "e
 told from a missing restore** — write a sentinel into it first. The same shape had already been
 paid for once in that test, for the flag half, and was reintroduced for the record half.
 
+
+## Issue #153 — one family shape, three rounds, and the self-test that ended it
+
+The branch added a content-granular readiness comparison. Three of its guards exist for the same
+reason: the artifact they read is host-authored but not schema-checked, and the evaluator that reads
+it promises a verdict rather than an exception, so a malformed value has to become a stale verdict
+instead of a traceback. All three were tested with a family of malformed values, and all three
+families were built by imagination.
+
+What that cost, in order:
+
+- **Round 0.** `levels[nk] = n.get("topo_level") or 0` feeding `list.sort`. A `topo_level` of `"0"`
+  raises `TypeError: '<' not supported between instances of 'int' and 'str'`. Found while reading a
+  code-motion survivor pair, not by a family — the family did not exist yet.
+- **Round 1.** `for n in all_nodes or []`. Six "unusable documents" — `None`, `[]`, `"x"`, `{}`,
+  `{"all_nodes": None}`, `{"all_nodes": "x"}` — every one of which is either falsy or iterable, so
+  `{"all_nodes": 5}` raising was outside the family by construction. The fix added the guard, and a
+  self-test asserting the family straddles `iter()`.
+- **Round 2.** `if not isinstance(bindings, list) or not all(...)`, the sibling guard written in the
+  same change as round 1's. Its family's one non-list member was the string `"not-a-list"`, which is
+  iterable, so `all(... for b in bindings)` walked it character by character and the stale verdict
+  arrived through the SECOND clause. Deleting `not isinstance(bindings, list) or` left all three
+  suites green at their baseline counts — 1289 / 300 / 775, which is the unmutated per-file split
+  measured at the merge commit — while `closure_bindings: 5` raised inside the readiness evaluator.
+
+**Why more members would not have closed it.** Every family here was already 4-10 members. The
+members were numerous and all on one side; the count was never the problem. Two members with a
+self-test beat ten without one, because the self-test is what a later maintainer's added member has
+to satisfy.
+
+**What closed it.** Each family now loops its members through `iter()` in the test body and requires
+both a `TypeError` and a success before it uses them. The assertion is on the FAMILY, not on the
+subject, which is the only reason it survives the next edit: a member appended on one side turns the
+self-test red at the point of appending, rather than silently widening nothing.
+
+**The generalisation, and it is not limited to `iter()`.** A guard whose purpose is to not raise
+names an operation that raises — `for … in`, `sort`, `len`, subscripting, `.strip()` — and the
+family has to reach that operation from both sides. `isinstance(x, int)` accepting `bool` is the
+same trap one type down: round 0's fix wrote `isinstance(level, int) and not isinstance(level, bool)`,
+and round 2 found the test asserting `sorted(got)`, which is insensitive to every sort-key value the
+clause decides. **A guard about a SORT KEY needs an ordered assertion; a guard about ITERABILITY
+needs a non-iterable member. Read the clause and name what would observe it.**
+
+**Cross-reference.** This is the type case of "you measured a family and reported the conclusion" in
+SKILL.md, whose check (a) is "name a member for which the measurement could have failed". Asked of
+these three families, (a) answers immediately — and nobody asked it, three times, because a family of
+malformed values LOOKS like a family that could fail.

--- a/.claude/skills/atmofab-review-loop/references/sonnet-delegation.md
+++ b/.claude/skills/atmofab-review-loop/references/sonnet-delegation.md
@@ -1,9 +1,43 @@
 # Delegating verifiable review work to sonnet: the experiment log
 
-Twelve runs narrated here, newest first. SKILL.md counts THIRTEEN, and the extra one is not a
+Thirteen runs narrated here, newest first. SKILL.md counts FOURTEEN, and the extra one is not a
 miscount: PR #116's run is cited there (it reported that a ten-item mutant list a commit message
 referenced was recorded nowhere it could find) and was never written up in this file. Numbering
 skips 10 for that reason. SKILL.md carries the operational conclusion; this is the evidence.
+
+## Data point 14 (issue #153 / PR #154, round 1) — the checklist item that was wrong, and paid anyway
+
+**Circumstance: a normal run.** Two up-model judgment axes ran in parallel and both returned; this
+was the added third axis, as the operational conclusion prescribes. Brief: a seven-part checklist
+(suite figures, ruff deltas, token counts, back-checks by subject mutation, a
+new-failure-class correspondence table, a call-site count, and a prose-vs-implementation
+contradiction sweep). ~14 minutes, 68 tool calls.
+
+**What it found: 3 real, 0 noise.** The two record defects it reported were both real and both
+confirmed independently by the up-model correctness axis the same round — the `59fb060` three-suite
+baseline (2314 recorded, 2336 measured) and a citation used in place of a measurement. Its
+back-check half re-ran all eight named subject mutations and confirmed each test fails when the
+thing it is about is broken. It also correctly reported that a phase document's "required keys" list
+is enforced by nothing, having looked in `tools/meta_contracts.py` and the `post_build` gate.
+
+**The valuable one was a REFUSAL, and it is the seventh of that kind.** Checklist item G asserted
+that `_dependency_binding_freshness`'s docstring claims to be "pure and NEVER raises" and asked it to
+find a counterexample. The docstring says no such thing — I had attributed the claim to the wrong
+function. It reported the premise as **not locatable**, then went and checked the functions that DO
+make that claim, and found `_closure_nodes_from_graph` raising `TypeError` on a non-iterable
+`all_nodes`. **That was the round's only live code defect.**
+
+**Why this is the shape to design a checklist for.** A reviewer answering the question as asked would
+have returned "not applicable" and been correct. What converted a defective item into the round's
+finding is the standing instruction to report an unlocatable claim rather than account for it — so the
+instruction is not merely a guard against my errors, it is the mechanism by which a wrong item still
+searches the right neighbourhood. **Keep the item's SUBJECT specific and its premise falsifiable**;
+a checklist that only asks about things I already have right cannot do this.
+
+**Limits, stated as usual.** The axis was mechanical throughout: it did not construct the driver-wire
+mutants that were the round's largest gap (three surviving mutants on the only production wire), and
+it did not attempt the over-refusal probe. Both went to the up-model axes, which is the split the
+operational conclusion already prescribes. Overlap with the up-model axes: 2 of its 3 findings.
 
 ## Data points 11-13 (issue #149 / PR #151, rounds 2 and 3) — three runs, and the first time the axis was load-bearing
 


### PR DESCRIPTION
Follow-up to #154 (issue #153). Skill-only: no production file, no test, no `docs/` change.

## What lands

Four additions, one stale count corrected in two places, and one new failure-attribution branch. Rules in `SKILL.md`, episodes in `references/`, per each file's own split.

| # | where | what |
|---|---|---|
| 1 | `atmofab-review-loop` SKILL + `references/mutation-testing.md` | **A type-guard's test family must straddle the type test, and assert that it does.** One shape cost three rounds on PR #154 after two diagnoses. More members do not close it; an `iter()` self-test in the test body does. |
| 2 | `atmofab-enforcement-change` rule 3 + `atmofab-review-loop`'s "the fix was to a RECORD" sign + `references/measurement-records.md` | **The trigger point for "do not write someone else's measurement as your own" is a CORRECTION.** A trigger-point gap, not a missing rule — the rule was there and I broke it writing the corrections bullet. |
| 3 | `atmofab-review-loop` SKILL round-0 rules | **Hand-revert a KILL that surprises you, not only a survivor.** `mutation_check.py` reported a hunk killed that a hand revert showed green; cause unidentified, so recorded as a caveat rather than a script change. |
| 4 | `atmofab-enforcement-change/references/failure-routing.md` | **An evaluator whose contract is a VERDICT, and what a raise from it costs.** A gate that raises fails closed by design; the same exception in a readiness evaluator aborts a whole `--with-deps` closure. |

**Counts corrected, both stale rather than wrong-when-written.** Codex clean has come back **twice** now (PR #67, issue #153), and both times the subagent sharing that round was not — on #153 it returned four findings, every one about a witness or a record rather than production behaviour. The sonnet experiment is at **fourteen** data points, with the false-premise refusal at seven of fourteen; #153's instance is the sharpest and is written up as data point 14, including what it did not cover.

`references/class-descent-log.md` gains the loop's own history: the class descended original design → fix → witnesses → records → prose — the cleanest recorded there — and the loop still stopped short of convergence with one of two proxy rounds.

## Why these four and not more

Each cost a round or produced a defect that shipped. Nothing here restates a canonical repository rule (that belongs in `docs/`), and item 2 is deliberately filed as a trigger-point gap rather than a new rule, because the rule existed and I had read it the same session.

## Verification

`test_skill_citations`, `test_development_doc_sync`, `test_skip_reasons_are_declared`, `test_readme_sync`: **79 passed, 67 subtests**. `test_skill_citations` reads every skill document out of the git index and requires each backticked repository path to be tracked, so the new pointers are checked rather than asserted.

**Provenance**, which is item 2 applied to this PR: every figure written here is one I measured — the per-file `1289 / 300 / 775` split and the six-revision I001 table were re-run for this commit. The three reviewers' mutant counts (22, 26, 11) are attributed to their reports and marked as not re-run; what I did reproduce and close by hand are the three survivors that came out of them.

`atmofab-review-loop/SKILL.md` net +44 lines and 1KB smaller than my first draft: the rules were tightened and the narration pushed into the reference files, which is that file's own discipline for staying loadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxmqMTSmKeXvAMPyWFMKZJ