### PR TITLE
skills: two traps issue #153 produced

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -120,7 +120,12 @@ no compiler installed).
 **3. Changing a rule is not done until you have swept the prose that cites that rule as grounds.**
 Use the grep procedure in `references/verification.md`. **Right after you write a sentence,
 execute it**: numbers, rule ids, compiler diagnostics and "X catches this" are all executable
-claims, and **write a range when the number varies**; and **the flip side of rule 3 is that prose you newly write in the same commit is
+claims, and **write a range when the number varies**; **executing it is not enough if the probe was
+contaminated** — a compiler writes artifacts beside its input and reads them back, so a shape can
+be answered by what the PREVIOUS shape left, and a cleanup line between two probes makes one
+recorded row into two environments (issue #153 recorded a `gfortran` rc=0 that holds only with a
+stale `.smod` present, beside a rc=1 taken after the `rm`; `references/verification.md`
+§"Verification steps that silently do not run" carries the reproduction); and **the flip side of rule 3 is that prose you newly write in the same commit is
 unverified until you run it** (L128 got four freshly written measurements or citations wrong
 inside the fix itself). **Do not write someone else's measurement as your own** — cite the source
 explicitly, or re-measure before writing. **The place this fires that you will not expect is a

--- a/.claude/skills/atmofab-enforcement-change/references/verification.md
+++ b/.claude/skills/atmofab-enforcement-change/references/verification.md
@@ -83,10 +83,48 @@ python3 -m pytest tools/tests/ -q -p no:randomly
 
 ## Verification steps that silently do not run, and records that silently do not hold
 
-All of these were hit on issue #71, and each looks exactly like a passing step or a kept
-record. (An earlier version of this heading said "two ways" over five items — a hand-typed
-count, rotting inside the commit that wrote it, in the file that tells you not to hand-type
-counts.)
+Each of these looks exactly like a passing step or a kept record. All but the first were hit on
+issue #71; the compiler-probe one is issue #153's, added 2026-09-05 — so do not read the list as
+one incident's inventory, which is what "all of these were hit on issue #71" made it while that
+sentence stood alone. (An earlier version of this heading also said "two ways" over five items — a
+hand-typed count, rotting inside the commit that wrote it, in the file that tells you not to
+hand-type counts. The fix then was to stop counting them here; the fix now is to stop attributing
+them to one issue.)
+
+**A COMPILER PROBE IS STATEFUL IN ITS WORKING DIRECTORY, and the artifact the PREVIOUS shape left
+can supply exactly what the next one is missing.** `gfortran` writes `.mod` / `.smod` beside the
+source and reads them back on the next invocation, so probing shape B where shape A just ran is not
+a measurement of B. Issue #153 shipped a wrong record that way, and the mechanism is narrower than
+"reuse of a name" — re-derived here, because a first version of this entry stated it loosely and
+did not reproduce:
+
+```
+B alone, clean directory                      -fsyntax-only rc=1   ("Module file
+                                                                    'hx_model.smod' has not
+                                                                    been generated")
+A compiled first (same module AND same
+procedure name), then B in that directory     -fsyntax-only rc=0    -c rc=0
+```
+
+A stale `.smod` for a DIFFERENT procedure changes nothing (measured): the leftover has to satisfy
+the very thing the next shape lacks. So the tell is not "these fixtures share a name" but **"the
+previous shape could have produced what this one needs"**.
+
+- **One fresh directory per shape.** `tempfile.mkdtemp()` per probe, not one directory for the
+  family. `rm -f *.mod *.smod` between runs is the same rule in the form that is one forgotten
+  line from failing.
+- **The worst version is a cleanup line BETWEEN the two halves of one measurement.** That is what
+  actually happened: `-fsyntax-only` ran in the contaminated directory, an `rm` ran next, and `-c`
+  ran in the now-clean one. The row recorded "rc=0 / rc=1" as one probe of one shape, and the
+  contrast between the two numbers — which looked like a finding about the syntax stage — was
+  entirely the directory changing underneath them. **Two numbers in one row must come from one
+  environment; if a cleanup sits between them, they are two measurements and neither says what the
+  row claims.**
+- **This generalises past compilers.** Any tool that writes an artifact beside its input and reads
+  it back — a build system's object cache, a linter's cache, `ruff` without `--no-cache` — has the
+  shape. On the same issue two ruff figures were wrong for the other reason (taken before the
+  round's last edits), which is the other half of the discipline: **one environment per row, and
+  every figure taken after the last edit**
 
 **`cmd | tail && git commit` does not gate on `cmd`.** A pipeline exits with the status of its
 LAST element, so `python3 -m pytest … | tail -3 && git commit` commits whatever pytest did — the

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -165,7 +165,15 @@ when a rule does not obviously apply:
   and `--test-cmd`, baseline green in both. **The verdict you keep is the one you can reproduce by
   hand**; report an unreproducible kill as such rather than banking it, because "every hunk is
   pinned" is what a reader will quote back. **The tell is a kill on a hunk you cannot name a
-  behaviour for**
+  behaviour for — and the sharpest instance of that tell is a hunk that is half of a code
+  MOTION**, which the prose-annotation bullet above already calls an EXPECTED survivor. When the
+  script reports one of those `killed`, two rules of this file contradict each other, and the
+  hand revert is how you find out which. Issue #153 hit it a second time: the extraction of
+  `_structure_reading` out of `_fortran_procedure_envelopes` was reported killed, and reverting
+  exactly that hunk by hand — restoring the inline block while the extracted function stayed —
+  left the file green, as a behaviour-preserving motion must. Cause unidentified both times, so
+  do not spend the round on it; **spend the two minutes on the revert, and report the kill as
+  unreproducible rather than counting it toward "every hunk is pinned"**
 - **If the change's mechanism lives inside a test file, hunk mutation does not apply** — "nothing
   to check" with a correct base is **not applicable, not a pass**, and `--include-tests` does not
   rescue it (reverting an ADDED test hunk deletes an assertion, so it always survives; a hunk

--- a/.claude/skills/atmofab-review-loop/references/mutation-testing.md
+++ b/.claude/skills/atmofab-review-loop/references/mutation-testing.md
@@ -169,6 +169,28 @@ In the same PR one decision, `closed = True`, sat inside a hunk of `@@ -36,11 +4
 lines as one block, which any of those 200 lines kills. Past 50 lines, re-target each judgment
 inside the hunk individually.
 
+## A motion half reported KILLED, twice, and neither reproduced (issue #153, 2026-09-05)
+
+The second instance of "hand-revert a kill that surprises you", and the one that gives the rule a
+trigger you can apply without judgment.
+
+`23438e3` extracted `_structure_reading` out of `_fortran_procedure_envelopes` — a pure motion,
+AST-token-identical to the block it replaced apart from the annotation, verified separately. The
+sweep (`--range HEAD~1..HEAD --paths tools`, baseline green in 52s, 6 hunks in 268s) reported the
+motion's DELETION half `killed`. Reverting exactly that hunk by hand — restoring the inline block
+while the extracted function stayed in place — left `tools/tests/test_validate_pipeline_semantics.py`
+at **855 passed**. Green, as a behaviour-preserving motion must be.
+
+Cause unidentified, as in the first instance. What is new is that this file and `SKILL.md` already
+contain the contradiction: the prose-annotation bullet says one half of a code move is EXPECTED to
+survive, and the sweep said `killed`. **Two rules of the skill disagreeing about one hunk is the
+cheapest trigger there is**, and it costs one revert to resolve. The first instance was found by
+noticing the hunk had no behaviour to name — a judgment call; this one is mechanical.
+
+The wrong move is to spend the round diagnosing the script. Report the kill as unreproducible,
+keep the verdict you reproduced by hand, and do not count it toward "every hunk is pinned" — which
+is the sentence a later reader will quote back.
+
 ## Handwritten harnesses: three harms in one PR (PR #53)
 
 - `str.replace` rewrites **every occurrence at once**. The same rule lived in three gates, so


### PR DESCRIPTION
Both skills instruct, at the end, to judge whether the session made them stale or exposed a gap, and to **tell the user rather than rewrite silently**. Two gaps, agreed before writing. Rule in `SKILL.md`, reproduction in `references/`, as both skills require.

## 1. `atmofab-enforcement-change` — a compiler probe is stateful in its working directory

`gfortran` writes `.mod` / `.smod` beside the source and reads them back, so probing shape B in the directory where shape A just ran is not a measurement of B. Issue #153 shipped a wrong record that way and corrected it during review.

**The mechanism is narrower than my first draft said, and I found that out the way the file tells you to.** The draft claimed a fixture family "sharing one module name" carries the previous answer forward; I ran it before committing and it did not reproduce — a stale `.smod` for a *different* procedure changes nothing. What is required is that the leftover satisfy the very thing the next shape lacks. Re-derived and recorded as a table:

| | |
|---|---|
| B alone, clean directory | `-fsyntax-only` **rc=1** |
| A compiled first (same module **and** same procedure name), then B in that directory | `-fsyntax-only` **rc=0**, `-c` **rc=0** |

So the tell is not "these fixtures share a name" but **"the previous shape could have produced what this one needs"**.

That also sharpened what the original defect *was*. The record it produced read "rc=0 / rc=1", which looked like a finding about the syntax stage — and neither number was wrong on its own: `-fsyntax-only` ran in the contaminated directory, an `rm` ran next, and `-c` ran in the now-clean one. **Two numbers in one row must come from one environment; a cleanup line between them makes it two measurements, and neither says what the row claims.** That is the entry's most transferable sentence and it is not about compilers — it applies to any tool that writes an artifact beside its input and reads it back.

## 2. `atmofab-review-loop` — a motion half reported KILLED

"Hand-revert a kill that surprises you" existed with one instance and a judgment-call tell ("a kill on a hunk you cannot name a behaviour for"). Issue #153 gave it a second instance and a **mechanical** trigger:

The prose-annotation bullet already states that one half of a code move is an EXPECTED survivor. So a `killed` verdict on a motion half is **two rules of the skill contradicting each other about one hunk** — and the revert costs two minutes. Measured: the extraction of `_structure_reading` was reported killed; a hand revert restoring the inline block, with the extracted function left in place, kept the file at 855 passed, as a behaviour-preserving motion must.

Cause unidentified both times, so the entry says not to spend the round diagnosing the script — report the kill as unreproducible and keep the verdict you reproduced by hand.

## Also

Corrected the section heading the first entry landed under. It said "all of these were hit on issue #71", which the new entry made false. It had already been rewritten once for a hand-typed count; the fix then was to stop counting the items, the fix now is to stop attributing them to one issue.

Skill-adjacent suites green: 357 passed, 520 subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxmqMTSmKeXvAMPyWFMKZJ