### PR TITLE
review-loop: the batch-edit rule's trigger, and reading a sectioned log (#161)

### DIFF
--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -298,13 +298,31 @@ when a rule does not obviously apply:
      rules, both cheap: **one write per edit, verified after the write** (re-read the file and
      assert the new text is in it, not that the old text was in it), and **never let an assertion
      for edit N+1 sit between edit N and its write**. A review round found it; nothing else could
-     have, because every symptom was in a document no test read
+     have, because every symptom was in a document no test read.
+     **The trigger is MORE THAN ONE EDIT IN ONE SCRIPT, not "a script that substitutes numbers"** —
+     and that distinction is why this rule failed a second time, on issue #161, after I had read it
+     the same session. There the two edits were PROSE, in `TODO.md`, and neither raised: the second
+     `write_text` was built from the pre-edit-1 text and silently overwrote the first, so the commit
+     shipped claiming a correction the file did not carry. Nothing about numbers was involved, which
+     is exactly why the rule did not come to mind while writing the script. Verify the write, not the
+     intent, for **every** edit — including the ones that are only words
    - **And then verify the substitution RAN.** The remedy has its own failure mode: PR #98 escalated
      to scripted substitution after four hand-typed numbers came out wrong, and the very next commit
      shipped with **eight unsubstituted `{PLACEHOLDER}` tokens in its message**, directly under the
      sentence saying the numbers were no longer typed (an f-string ate the doubled braces). Assert
      that no placeholder survives before you commit — one `re.search` — because a message cannot be
      fixed after it is pushed, and this failure looks exactly like success
+   - **When the measurement is a FAILURE read out of a sectioned log, map each line to its own
+     section before you quote it.** A CI log, a `pytest` FAILURES block and a mutation sweep's
+     output all print `header` then `detail`, repeatedly, and the eye slides from one section's
+     header to the next section's error. On issue #161 I attributed a test's failure to an error
+     belonging to the section BELOW it, wrote that into a commit message and then into `TODO.md`,
+     and a review round found it two commits later — after which my own correction got the same
+     detail wrong for one of the three runs. The mechanical form is one loop: walk the log, keep
+     the last header seen, and emit `(header, error)` pairs; quote from the pairs, never from the
+     scroll. **Reading it yourself is not the safeguard** — this is the same class as writing
+     someone else's measurement as your own, with the same cure, and the fact that you ran the
+     command does not make what you read off it a measurement
    - **Before you DERIVE a threshold from a measurement, enumerate the comparable runs you already
      have.** Generating a number from the artifact stops transcription errors and does nothing
      about this one: on PR #100 a requirement inferred from one closure was falsified by the NEXT

--- a/.claude/skills/atmofab-review-loop/references/measurement-records.md
+++ b/.claude/skills/atmofab-review-loop/references/measurement-records.md
@@ -124,3 +124,70 @@ neither reviewer had done was measure at the commit the sentence would name.
 messages — several to the exact traceback line, assertion text and per-file digit — and found nothing
 else wrong. The rewrite into "historical record naming the commit and the command" held; the one
 failure was the entry written from someone else's measurement.
+
+
+## Issue #161 — the batch-edit rule, broken again on prose, by someone who had just read it
+
+PR-3's commit `9cb5a7f` said it had corrected a `TODO.md` figure and listed the seven entries the
+correction named. **The edit never reached the file.** One `python3 - <<PY` block made two changes
+to `TODO.md`; the second `p.write_text(...)` was built from `t`, the text read BEFORE the first
+change, so it silently reverted it. Neither edit raised, so there was no traceback to misread — the
+PR #116 shape without the exception.
+
+It was caught one command later, by re-reading the file, which is the rule's own remedy. The commit
+had already been made.
+
+**Why the rule did not fire.** It lives in `SKILL.md` §"Before you hand it over" item 2, under the
+heading *"Do not type measured values by hand; generate them from the artifact you measured"*, and
+every episode under it is about NUMBERS. This edit was two paragraphs of prose about what a scanned
+set contains. I had read the section that session — for the measurement rules — and did not connect
+it, because nothing about the task looked like transcribing a measurement. The rule was there; its
+trigger point was somewhere else. `SKILL.md` now states the trigger as **more than one edit in one
+script**, which is the property that actually decides it.
+
+The correction was recorded rather than the sentence quietly replaced, per the issue #153 rule
+above: the bullet says it first read `51 / 2430`, then `2433`, and why each was wrong.
+
+
+## Issue #161 — a failure read off the wrong section of a CI log, twice
+
+The branch that added CI pushed one change at a time and read the runner, which is how three of the
+plan's predictions were falsified. Run 1 reported eight failures. I read the FAILURES block and
+recorded that `RunWorkflowTests::test_orchestration_claim_outlives_the_tmp_cleanup` "dies on `codex
+features list failed: [Errno 2] No such file or directory: 'codex'`".
+
+It does not. Its assertion is `Lists differ: [True, False] != [False] : the claim must still be held
+while tmp is being removed`. The `codex features list` error belongs to a DIFFERENT section of the
+same block — `LeafUsageRecordingTests`, two sections below in run 1 and one below in runs 2 and 3.
+The pytest FAILURES block prints `____ Header ____` then the traceback then `E   ...`, repeatedly,
+and at three screens of scroll the eye carries a header forward past its own error.
+
+The consequences compounded in the way this file's other episodes predict:
+
+- it went into commit `16e752d`'s message as a measured fact;
+- it went into `TODO.md` as a durable record, framed as an intermittent — with "failed on runs 1-2
+  and passed on 3-6 **with nothing touching it**", which is also wrong: it fails on runs 1, 2 AND 3
+  and first passes on run 4, the run that changed the interpreter, so an environment change is a
+  live candidate cause and "not an intermittent at all" is the better hypothesis;
+- a review round found it two commits later;
+- and **my correction of it was itself wrong in one detail** — "belongs to the NEXT section" holds
+  for runs 2 and 3 and not for run 1, the run the misreading came from. Corrected again, and
+  recorded rather than replaced.
+
+**The cure is mechanical and takes one loop**, which is what round 3 used to verify the correction:
+
+```python
+name = None
+for line in log:
+    if re.match(r"^_+ [A-Za-z].*_+$", line):
+        name = line.strip("_ ")
+    elif line.startswith("E ") and name:
+        print(name, "||", line)
+        name = None
+```
+
+**What makes this worth a rule of its own** is that every existing guard here is about someone
+else's number. `atmofab-enforcement-change` rule 3 says do not write a reviewer's measurement as
+your own; issue #153 above says re-measure at the commit you are about to name. Both assume the
+danger is a figure you did not produce. This one I produced myself, from a command I ran, on a log I
+opened — and running the command is not what makes the reading a measurement.


### PR DESCRIPTION
Two updates to `atmofab-review-loop` from issue #161, both of the shape the skill's own §Finally asks for — **not "the rule was missing" but "the rule was there and its trigger point was elsewhere"** — plus one class it does not cover.

## 1. The batch-edit rule's trigger was written as "numbers"

Round-0 item 2 already says *one write per edit, verified after the write*. It sits under the heading **"Do not type measured values by hand; generate them from the artifact you measured"**, and every episode beneath it is about numbers.

On #161 I broke it on **prose**: one script made two edits to `TODO.md`, the second `write_text` was built from the pre-edit-1 text and silently reverted the first, and the commit shipped claiming a correction the file did not carry. Neither edit raised — PR #116's shape without the exception, so there was no traceback to misread. I had read that section the same session, for the measurement rules, and did not connect it, because nothing about the task looked like transcribing a measurement.

The rule now names the trigger as **more than one edit in one script**, which is the property that actually decides it.

## 2. Reading a failure out of a sectioned log — a class with no rule here

A CI log, a `pytest` FAILURES block and a mutation sweep's output all print `header`, then `detail`, repeatedly. At three screens of scroll the eye carries a header forward past its own error.

I recorded `RunWorkflowTests::test_orchestration_claim_outlives_the_tmp_cleanup` as dying on a `codex features list` error that belongs to the section below it. It went into a commit message, then into `TODO.md` as a durable record framed as an intermittent — and a review round found it two commits later. **My correction was then wrong in one detail itself**: "belongs to the NEXT section" holds for two of the three runs and not for the one the misreading came from.

The new rule is one loop — walk the log, keep the last header, emit `(header, error)` pairs, quote from the pairs — and it was **executed before being published**, on the real run-1 log. It reproduces the correct mapping, including the pair I had got wrong.

Why it earns its own rule rather than a note under an existing one: every guard in that section assumes the danger is *someone else's* number. `atmofab-enforcement-change` rule 3 says do not write a reviewer's measurement as your own; issue #153's episode says re-measure at the commit you are about to name. This one I produced myself, from a command I ran, on a log I opened — and running the command is not what makes the reading a measurement.

## Shape

Rules in `SKILL.md`, episodes in `references/measurement-records.md`, which is the split that file states. +20 lines and +67 lines respectively.

`atmofab-enforcement-change` needs no update, and that judgment is stated rather than left implicit: the three PRs produced no new dual-read pair, no new failure-routing category, no new input surface and no deterministic substep wiring, and its verification commands all ran as written.

## Measurements

`tools/tests/`: **5872 passed, 3168 subtests, 0 skipped, 0 failed**. `test_skill_citations` and `test_backend_boundary` green — the skill files are read by the first and scanned by neither's ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxmqMTSmKeXvAMPyWFMKZJ
