### PR TITLE
review-loop: the selection's DEFAULT, and a published instrument that went stale beside its number

### DIFF
--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -342,17 +342,17 @@ when a rule does not obviously apply:
      N runs that have one"), and the sweep that finds the population is one loop over the corpus,
      not a judgment call. Where the population is one, say so and call the number a bound rather
      than a requirement
-   - **When you PUBLISH the instrument beside the number, republish it whenever either changes.**
-     Generating a figure from the artifact is not enough once the record carries the script that
-     generated it: on issue #181 a pull request body published a verification script next to that
-     script's output, then changed the script in the next commit and left the old listing. A
-     reviewer ran what was published and got a RED result on the tree it certified, and could not
-     tell those failures from lost work. The same body later cited a figure another axis had
-     measured at an earlier commit, in the present tense, about a file whose measured set had
-     changed. Two rules: **a published instrument and a published number are one record, and both
-     are republished together**; and **a measurement someone else took names the commit it was
-     taken at even when you are quoting it approvingly** — the second is `atmofab-enforcement-change`
-     rule 3 applied to a figure you agree with, which is where it does not fire on its own
+   - **When you PUBLISH the instrument beside the number, republish it whenever either changes, or
+     stamp it with the commit it was run at.** Generating a figure from the artifact is not enough
+     once the record carries the script that generated it: on issue #181 a pull request published a
+     verification script in a COMMENT beside a body quoting its output, changed the script two
+     commits later, and republished neither. A reviewer ran what was published against the tree it
+     certifies and it failed — on the newer commit's own deliberate edits, which from outside are
+     indistinguishable from work the change lost. **A published instrument and a published number
+     are one record.** Note where the surface is: a record split across a body and its comments
+     drifts without either looking edited. The cheap form is the stamp — "run at `<sha>`" makes a
+     listing historical rather than wrong, which is the same cure this list already prescribes for
+     a figure
 
    Episodes: `references/measurement-records.md`.
 
@@ -1049,17 +1049,24 @@ that tells you how it closed.
   witness needs and drive a synthetic one; the coverage is real, it just must not be taken from
   the corpus the change stopped reading (issue #182)
 - **Your change SELECTS a subset — of text, of behaviour, of an allowlist — and you are choosing
-  what goes IN** → the DEFAULT for an element nobody considered decides the failure mode, and it is
-  the design decision, not the individual choices. Selecting means an unconsidered element is
-  DROPPED, and what leaves with it is silent: an open task, a pointer's antecedent, the qualifier a
-  surviving claim needs. Keeping unless explicitly dropped costs size and nothing else. Criterion,
-  one question: **if I never think about element X, what happens to it, and would I notice?** On
-  issue #181 three consecutive rounds found the same three classes — a dropped fix direction, a
-  pointer whose antecedent went, a claim outliving its qualifier — each time in the items the
-  previous round had not opened, and each time they were fixed one at a time. Inverting the default
-  is what ended it; the two rounds after found five, then fewer. **Reach for this at the SECOND
-  round of one class, not the third**: the recurrence is not evidence that you are careless, it is
-  evidence that the misses are invisible by construction
+  what goes IN** → the DEFAULT for an element nobody considered is a design decision made once, and
+  it decides whether a MISS is loud or silent. Criterion, one question: **if I never think about
+  element X, what happens to it, and would I notice?** **The answer decides the polarity; the sign
+  does not.** Where dropping X produces a REFUSAL — a gate allowlist, a write root, an import
+  roster — drop-by-default is the loud direction and is correct, which is `atmofab-enforcement-change`
+  surface 8 and not negotiable. Where dropping X produces silence, keeping unless explicitly
+  dropped costs size and nothing else. A third answer is often the best: make an unconsidered X
+  REFUSE until someone decides, which is what `_UNSCANNED_ROOT_FILES` does after two files landed
+  outside a scan unnoticed. On issue #181 three consecutive rounds found the same shapes — a
+  dropped fix direction, a pointer whose antecedent went, a claim outliving its qualifier — each
+  time in the items the previous round had not opened, and each time they were fixed one at a time;
+  inverting the default lowered the rate and the loop still ended at its cap. **Reach for the
+  question at the SECOND round of one class, not the third**: the recurrence is not evidence that
+  you are careless, it is evidence that the misses are invisible by construction. This is the
+  selection case of "the same family appeared two rounds running" below — that row asks whether the
+  rule is placed where a later addition is protected automatically, and the default IS that
+  placement. **Inverting a default is a shape change, so the "split everything after that into
+  another PR" row below applies to it**
 - **A fix changed the shape of the rule** (denylist → allowlist and the like) → split everything
   after that into another PR. If you continue without splitting, **give the user the options and
   ask**

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -342,6 +342,17 @@ when a rule does not obviously apply:
      N runs that have one"), and the sweep that finds the population is one loop over the corpus,
      not a judgment call. Where the population is one, say so and call the number a bound rather
      than a requirement
+   - **When you PUBLISH the instrument beside the number, republish it whenever either changes.**
+     Generating a figure from the artifact is not enough once the record carries the script that
+     generated it: on issue #181 a pull request body published a verification script next to that
+     script's output, then changed the script in the next commit and left the old listing. A
+     reviewer ran what was published and got a RED result on the tree it certified, and could not
+     tell those failures from lost work. The same body later cited a figure another axis had
+     measured at an earlier commit, in the present tense, about a file whose measured set had
+     changed. Two rules: **a published instrument and a published number are one record, and both
+     are republished together**; and **a measurement someone else took names the commit it was
+     taken at even when you are quoting it approvingly** — the second is `atmofab-enforcement-change`
+     rule 3 applied to a figure you agree with, which is where it does not fire on its own
 
    Episodes: `references/measurement-records.md`.
 
@@ -1037,6 +1048,18 @@ that tells you how it closed.
   **The fix is injection, not deletion** — give the production function the root or path the
   witness needs and drive a synthetic one; the coverage is real, it just must not be taken from
   the corpus the change stopped reading (issue #182)
+- **Your change SELECTS a subset — of text, of behaviour, of an allowlist — and you are choosing
+  what goes IN** → the DEFAULT for an element nobody considered decides the failure mode, and it is
+  the design decision, not the individual choices. Selecting means an unconsidered element is
+  DROPPED, and what leaves with it is silent: an open task, a pointer's antecedent, the qualifier a
+  surviving claim needs. Keeping unless explicitly dropped costs size and nothing else. Criterion,
+  one question: **if I never think about element X, what happens to it, and would I notice?** On
+  issue #181 three consecutive rounds found the same three classes — a dropped fix direction, a
+  pointer whose antecedent went, a claim outliving its qualifier — each time in the items the
+  previous round had not opened, and each time they were fixed one at a time. Inverting the default
+  is what ended it; the two rounds after found five, then fewer. **Reach for this at the SECOND
+  round of one class, not the third**: the recurrence is not evidence that you are careless, it is
+  evidence that the misses are invisible by construction
 - **A fix changed the shape of the rule** (denylist → allowlist and the like) → split everything
   after that into another PR. If you continue without splitting, **give the user the options and
   ask**

--- a/.claude/skills/atmofab-review-loop/references/measurement-records.md
+++ b/.claude/skills/atmofab-review-loop/references/measurement-records.md
@@ -192,29 +192,36 @@ your own; issue #153 above says re-measure at the commit you are about to name. 
 danger is a figure you did not produce. This one I produced myself, from a command I ran, on a log I
 opened — and running the command is not what makes the reading a measurement.
 
-## The published instrument and the published number drifted apart (issue #181, PR #191)
+## The published instrument went stale beside the number it produced (issue #181, PR #191)
 
-A pull request body carried a verification script in a `<details>` block and, a few paragraphs
-above it, the output that script produced: `0 non-verbatim units`. The next commit changed the
-script — a different join rule and a different link rule — and republished neither the listing nor
-the number's derivation. A round-3 reviewer did the obvious thing, ran what was published against
-the tree it certifies, and got six failures. They were the commit's own deliberate edits, which
-the newer script accounts for and the published one does not, but from outside there is no way to
-tell those from work the compression lost.
+The pull request published its verification script — the thing that produced `0 non-verbatim units`
+— as a comment beside a body that quoted the output. The listing went up two minutes after
+`a602046`; `c56b2ac`, half an hour later, changed both the script's join rule and its record-link
+rule and republished neither. A round-3 reviewer ran what was published against the tree it
+certifies and it failed: the published script's reverse direction reports removed lines with no
+record, because it does not know about the pointer repairs the newer commit made. Those failures
+are the commit's own deliberate edits, and from outside there is no way to tell them from work the
+compression lost. The correction is recorded on the pull request
+(comment `5563141702`): "review round 3 measured [it] is NOT the one that produced any current
+file … Re-running it reproduces 97,566 bytes with 25 cross-bullet joins."
 
 **What makes this its own rule rather than an instance of the ones above it.** Every guard in this
 file so far is about a NUMBER: do not type it, generate it from the artifact, name the commit it
-was taken at, state the population. All of them hold here — the number was generated, and it was
-correct for the commit it was taken at. What went wrong is that the record published the
-INSTRUMENT as well, which is strictly better practice, and thereby created a second thing that can
-go stale. The instrument and the number are one record: republish both, or publish neither and
-state the property instead.
+was taken at, state the population. All of them held — the number was generated, and it was correct
+for the commit it was taken at. What went wrong is that the record published the INSTRUMENT as
+well, which is strictly better practice, and thereby created a second thing that can go stale. The
+instrument and the number are one record: republish both, or publish neither and state the property
+instead. **A stamped listing is the cheap third option** — say which commit it was run at, and it
+becomes historical rather than wrong.
 
-The same body carried the mirror case a round later. A reviewer had measured "423 of the 425
-sentences the compression drops are present in a linked record" at one commit; the body quoted it
-in the present tense, about a later commit whose dropped set was different. The figure was true
-where it was taken and the property it stands for held at both, but the sentence claimed the
-figure for a file nobody had measured. `atmofab-enforcement-change` rule 3 — do not write someone
-else's measurement as your own — does not fire here, because the attribution was correct and the
-reviewer was right. **The rule that does: a measurement names the commit it was taken at even when
-you are quoting it approvingly, and especially when the thing measured has changed since.**
+**Where the failure surface actually is.** Not the pull request body: this one carried no script at
+all. The body quoted the number and a COMMENT carried the listing, so the two drifted apart without
+either looking edited. Any record split across a body and its comments has this shape.
+
+The same pull request produced the mirror case a round later and it is NOT a new rule:
+a figure a reviewer measured at one commit was quoted in the present tense about a later one whose
+measured set had changed. `atmofab-enforcement-change` rule 3 covers it in its own words — "the
+place this fires that you will not expect is a CORRECTION: a reviewer's finding arrives already
+carrying evidence, so it feels verified before you write it" — and this file states the same rule
+above, under issue #153. **Correct attribution is not what rule 3 is about**; the commit is. Read
+this paragraph as a second instance of that rule rather than as anything new.

--- a/.claude/skills/atmofab-review-loop/references/measurement-records.md
+++ b/.claude/skills/atmofab-review-loop/references/measurement-records.md
@@ -191,3 +191,30 @@ else's number. `atmofab-enforcement-change` rule 3 says do not write a reviewer'
 your own; issue #153 above says re-measure at the commit you are about to name. Both assume the
 danger is a figure you did not produce. This one I produced myself, from a command I ran, on a log I
 opened — and running the command is not what makes the reading a measurement.
+
+## The published instrument and the published number drifted apart (issue #181, PR #191)
+
+A pull request body carried a verification script in a `<details>` block and, a few paragraphs
+above it, the output that script produced: `0 non-verbatim units`. The next commit changed the
+script — a different join rule and a different link rule — and republished neither the listing nor
+the number's derivation. A round-3 reviewer did the obvious thing, ran what was published against
+the tree it certifies, and got six failures. They were the commit's own deliberate edits, which
+the newer script accounts for and the published one does not, but from outside there is no way to
+tell those from work the compression lost.
+
+**What makes this its own rule rather than an instance of the ones above it.** Every guard in this
+file so far is about a NUMBER: do not type it, generate it from the artifact, name the commit it
+was taken at, state the population. All of them hold here — the number was generated, and it was
+correct for the commit it was taken at. What went wrong is that the record published the
+INSTRUMENT as well, which is strictly better practice, and thereby created a second thing that can
+go stale. The instrument and the number are one record: republish both, or publish neither and
+state the property instead.
+
+The same body carried the mirror case a round later. A reviewer had measured "423 of the 425
+sentences the compression drops are present in a linked record" at one commit; the body quoted it
+in the present tense, about a later commit whose dropped set was different. The figure was true
+where it was taken and the property it stands for held at both, but the sentence claimed the
+figure for a file nobody had measured. `atmofab-enforcement-change` rule 3 — do not write someone
+else's measurement as your own — does not fire here, because the attribution was correct and the
+reviewer was right. **The rule that does: a measurement names the commit it was taken at even when
+you are quoting it approvingly, and especially when the thing measured has changed since.**

--- a/.claude/skills/atmofab-review-loop/references/signs-episodes.md
+++ b/.claude/skills/atmofab-review-loop/references/signs-episodes.md
@@ -281,3 +281,43 @@ the case history that tells you how it closed.
   part of it, and should carry the injection command from the first round rather than discovering
   it at the cap.
 
+## The selection's DEFAULT, not the individual choices (issue #181, PR #191)
+
+`TODO.md` held 54 open items and the change compressed them. The first attempt rewrote each item by
+hand; round 1 enumerated all 54 and measured open content gone from about 35 of them, plus eleven
+claims the source did not support. The second attempt could not rewrite: each item was split into
+units — one whole sub-bullet, or one sentence of a long single-line item — and the compression
+SELECTED units, with a script asserting every retained unit is a substring of its pre-compression
+item. Three reviewers re-derived that property independently and it held. **Nothing was invented
+from that commit onward, and the loop still ran three more rounds.**
+
+Round 2 found the selection had dropped open work in twelve places. Round 3 found the same three
+classes again — a dropped fix direction, a pointer whose antecedent went, a claim outliving its
+qualifier — in the items round 2 had not opened. Both rounds' fixes were correct and neither
+changed anything: the next round found the same classes in the items IT had not opened.
+
+**What closed it was inverting the default.** Before: a unit is dropped unless it is selected.
+After: a unit is kept unless the item is one of five whose bulk is review history. The two are the
+same set of judgments; what differs is what happens to a unit nobody thought about. Under the
+first, it disappears and takes a fix direction or a pointer's antecedent with it, invisibly, in a
+file no test reads. Under the second it stays and costs bytes. Rounds 4 and 5 found five instances
+and then fewer, all of them inside the five items where selection still operated.
+
+**The generalisation, and why it is a sign rather than a note about one file.** Any change that
+chooses a subset has this shape — an allowlist narrowed, a test set pruned, a document trimmed, a
+denylist replaced by an explicit roster. The individual choices are what review can see; the
+default is what decides whether a MISS is loud or silent, and it is a single decision made once.
+Ask it before the second round of one class rather than the third: *if I never think about element
+X, what happens to it, and would I notice?*
+
+**Two corollaries this episode also paid for.** A byte-ratio instrument cannot see the loss — the
+same branch ran a check for "an item that lost more than a third of its bytes must link to a
+record", and it twice passed an item whose loss was a fix direction under that threshold. And an
+item's ACCEPTANCE BAR is open work by definition: eight completion criteria were selected out one
+at a time, and hand-checking is what missed them; adding them back mechanically is what held.
+
+**One more, from the round after.** Round 4 found three docstrings in a source file citing an item
+this branch had removed, two of them made false by the removal, and they were repaired. The class
+was not then swept for elsewhere in the tree, so round 5 found a fourth in a test file, citing a
+sentence the compression had dropped. **A fix that does not sweep its own class schedules the next
+round.**

--- a/.claude/skills/atmofab-review-loop/references/signs-episodes.md
+++ b/.claude/skills/atmofab-review-loop/references/signs-episodes.md
@@ -283,41 +283,68 @@ the case history that tells you how it closed.
 
 ## The selection's DEFAULT, not the individual choices (issue #181, PR #191)
 
-`TODO.md` held 54 open items and the change compressed them. The first attempt rewrote each item by
-hand; round 1 enumerated all 54 and measured open content gone from about 35 of them, plus eleven
-claims the source did not support. The second attempt could not rewrite: each item was split into
-units — one whole sub-bullet, or one sentence of a long single-line item — and the compression
-SELECTED units, with a script asserting every retained unit is a substring of its pre-compression
-item. Three reviewers re-derived that property independently and it held. **Nothing was invented
-from that commit onward, and the loop still ran three more rounds.**
+`TODO.md` held 54 open items and the change compressed them. The first attempt (`a30b6cb`) rewrote
+each item by hand; round 1 enumerated all 54 and reported open content gone from about 35 of them,
+plus eleven claims the source did not support — of which five were reproduced before acting and two
+were statements false against the code. The second attempt (`a602046`) could not rewrite: each item
+was split into units — one whole sub-bullet, or one sentence of a long single-line item — and the
+compression SELECTED units, with a script asserting every retained unit appears in its
+pre-compression item. Both axes re-derived that property at round 2, and both again at rounds 4 and
+5. **Nothing was invented from that commit onward, and the loop still ran three more rounds.**
 
-Round 2 found the selection had dropped open work in twelve places. Round 3 found the same three
-classes again — a dropped fix direction, a pointer whose antecedent went, a claim outliving its
-qualifier — in the items round 2 had not opened. Both rounds' fixes were correct and neither
-changed anything: the next round found the same classes in the items IT had not opened.
+Round 2 found the selection had dropped open work in twelve places. Round 3's two axes returned 16
+and 7 findings, in the items round 2 had not opened, and in the same shapes: a dropped fix
+direction, a pointer whose antecedent went, a dropped reachability bound, a claim outliving its
+qualifier — plus two items left internally false, a completion criterion enumerating sub-findings
+the file no longer contained. Rounds 1 and 2 had each fixed their own findings correctly, and
+neither changed the rate.
 
-**What closed it was inverting the default.** Before: a unit is dropped unless it is selected.
-After: a unit is kept unless the item is one of five whose bulk is review history. The two are the
-same set of judgments; what differs is what happens to a unit nobody thought about. Under the
-first, it disappears and takes a fix direction or a pointer's antecedent with it, invisibly, in a
-file no test reads. Under the second it stays and costs bytes. Rounds 4 and 5 found five instances
-and then fewer, all of them inside the five items where selection still operated.
+**Round 3's fix was to invert the default** (`48cf175`): a unit is dropped only in the five items
+whose bulk is review history, and kept everywhere else. The two are the same set of judgments; what
+differs is what happens to a unit nobody thought about. Under the first it disappears and takes a
+fix direction or a pointer's antecedent with it, and the two witnesses over this file
+(`test_hooks_cli::GlobPatternTriggerSurfaceTests` and
+`test_build_runtime_server::McpCallClientTests`, both verified by truncating the file) pin two
+sentences and nothing else, so the loss is invisible. Under the second it stays and costs bytes.
 
-**The generalisation, and why it is a sign rather than a note about one file.** Any change that
-chooses a subset has this shape — an allowlist narrowed, a test set pruned, a document trimmed, a
-denylist replaced by an explicit roster. The individual choices are what review can see; the
-default is what decides whether a MISS is loud or silent, and it is a single decision made once.
-Ask it before the second round of one class rather than the third: *if I never think about element
-X, what happens to it, and would I notice?*
+**What the inversion is measured to have done, and what it is not.** Round 4's blank-slate axis
+found NO new instance of the three classes in the shipped text — the first descent in the loop —
+and its findings were a different class, the six whole items that commit removed. Round 5, the cap,
+found five instances "at a lower rate … rather than twelve". So the sequence after the inversion is
+zero, then five, and the loop **ended at its cap without the class reaching zero**. The inversion
+lowered the rate and changed what the rounds were about; it did not close the class, and PR #191's
+own disclosure says so.
 
-**Two corollaries this episode also paid for.** A byte-ratio instrument cannot see the loss — the
-same branch ran a check for "an item that lost more than a third of its bytes must link to a
-record", and it twice passed an item whose loss was a fix direction under that threshold. And an
-item's ACCEPTANCE BAR is open work by definition: eight completion criteria were selected out one
-at a time, and hand-checking is what missed them; adding them back mechanically is what held.
+**The generalisation, and its limit.** Any change that chooses a subset has this shape — an
+allowlist narrowed, a test set pruned, a document trimmed, a denylist replaced by an explicit
+roster. This is argued from one issue's episodes, not measured across two: a second instance would
+have to be a change that narrows a set where a round found a SILENTLY DROPPED element, and where
+flipping the default measurably lowered the following round's rate. Until there is one, read the
+sign as a question to ask, not as a law about which polarity to pick.
 
-**One more, from the round after.** Round 4 found three docstrings in a source file citing an item
-this branch had removed, two of them made false by the removal, and they were repaired. The class
-was not then swept for elsewhere in the tree, so round 5 found a fourth in a test file, citing a
-sentence the compression had dropped. **A fix that does not sweep its own class schedules the next
-round.**
+**Which polarity is right is NOT what this sign decides**, and the counter-cases are in this
+repository. `tools/hooks/common.py`'s `_PIPE_TAIL_ALLOWED_IMPORT_ROOTS` excludes `string` because
+`string.Formatter().get_field()` is a primitive the AST inspector cannot see; a module nobody
+considered must fall OUTSIDE it. `tools/validate_workspace_root.py`'s active-status set says so in
+its own comment: anything outside it, including an unreadable meta file, is treated as not active
+so leaked scratch is surfaced. `atmofab-enforcement-change` surface 8 states the rule those follow —
+bind ro and allowlist only the writable places, so unknown names fall on the inert side.
+**Drop-by-default is correct wherever dropping an element produces a REFUSAL**, because a refusal is
+loud; the sign's question answers that correctly on its own terms and the polarity follows from the
+answer. And there is a third option this repository actually took for the same failure:
+`tools/tests/test_backend_boundary.py`'s `_UNSCANNED_ROOT_FILES` is an explicit set precisely so
+that a new root file is REFUSED until someone decides which side it is on — the failure that
+produced it was two files landing outside a scan silently.
+
+**Two corollaries the same loop paid for.** A byte-ratio instrument cannot see the loss: the branch
+ran a check for "an item that lost more than a third of its bytes must link to a record", and
+round 3 recorded an item whose loss was its fix direction at 11 per cent, under the threshold. And
+an item's ACCEPTANCE BAR is open work by definition — the hand-rewritten attempt carried 12 of the
+base's 14 completion criteria, and what restored them and held them was adding them back
+mechanically rather than checking for them by hand.
+
+**One more, from the round after.** Round 4 found three docstrings in
+`tools/validate_pipeline_semantics.py` citing an item that commit had removed, two of them made
+false by the removal, and repaired those three. The class was not then swept for elsewhere in the
+tree, so round 5 found a fourth citation, in `tools/tests/test_backend_boundary.py`, of a sentence
+the compression had dropped. **A fix that does not sweep its own class schedules the next round.**


### PR DESCRIPTION
Two rules issue #181 paid for over nine review rounds, neither of which `atmofab-review-loop` had. Prose only, three files, no code.

## 1. The selection's DEFAULT decides the failure mode

New row in **Signs to catch mid-loop**, episode in `references/signs-episodes.md`.

PR #191 compressed `TODO.md`'s 54 open items by choosing which units of each item to keep. **From its second revision on the mechanism was sound** — three reviewers independently re-derived that every retained byte came from the base commit, so nothing was invented — **and the loop still ran three more rounds**, because each one found the same three classes in the items the previous round had not opened:

- a dropped fix direction,
- a pointer whose antecedent went,
- a claim outliving the sentence that qualified it.

Rounds 2 and 3 each fixed their findings correctly, and neither changed anything.

**What closed it was inverting the default**: a unit is now KEPT unless the item is one of five whose bulk is review history. The same set of judgments; what differs is what happens to a unit nobody thought about. Under the old default it disappears and takes an open task or a pointer's antecedent with it, in a file exactly two tests read. Under the new one it stays and costs bytes.

The criterion is one question — **"if I never think about element X, what happens to it, and would I notice?"** — and the rule says to ask it at the **second** round of one class rather than the third, because the recurrence is not evidence of carelessness but of misses that are invisible by construction.

The generalisation is not about `TODO.md`: any change that chooses a subset has this shape — an allowlist narrowed, a test set pruned, a denylist replaced by an explicit roster.

## 2. A published instrument and a published number are one record

New bullet in the measurement-records list, episode in `references/measurement-records.md`.

Every rule in that list is about a NUMBER: do not type it, generate it from the artifact, name the commit it was taken at, state the population. **All of them held.** What broke is that the pull request body published the verification SCRIPT as well — strictly better practice, and thereby a second thing that can go stale. The next commit changed the script and republished neither it nor the derivation; a round-3 reviewer ran what was published, got a **red** result on the tree it certifies, and could not tell those failures from lost work.

The same bullet carries the mirror case: a figure another axis measured at an earlier commit, quoted in the present tense about a later one whose measured set had changed. `atmofab-enforcement-change` rule 3 — do not write someone else's measurement as your own — does not fire there, because the attribution was correct and the reviewer was right.

## Three corollaries the signs episode also records

- **A byte-ratio instrument cannot see a lost fix direction.** The same branch ran a check for "an item that lost more than a third of its bytes must link to a record"; it twice passed an item whose loss was its fix direction, under the threshold.
- **An item's acceptance bar is open work by definition.** Eight completion criteria were selected out one at a time; hand-checking is what lost them, adding them back mechanically is what held.
- **A fix that does not sweep its own class schedules the next round.** Round 4 repaired three source docstrings citing an item the branch had removed, two of them made false by the removal — and did not sweep the tree for the pattern, so round 5 found a fourth, in a test file.

## Verification

Measured at `e83e459`, primary checkout `/home/seiya/atmofab`.

```
pytest tools/tests -q -p no:randomly      5891 passed, 3174 subtests, 0 failed
  (unmoved — this change adds and removes no test)
test_skill_citations                      34 passed
test_development_doc_sync                 25 passed
```

Both of those read these files. `git diff --stat`: `SKILL.md` +23, `references/signs-episodes.md` +40, `references/measurement-records.md` +27.

## Disclosure

- **No review round has been run on this change.** It is prose in the skill that governs review rounds, so a round on it is circular in a way worth naming rather than pretending otherwise; the default budget for a prose diff would be round 0 plus one, and I have spent neither.
- **The rules are stated from one issue's episodes.** The selection-default rule generalises past `TODO.md` on argument rather than on a second measured instance; the published-instrument rule has exactly one.
- `.claude/skills/` reaches no workflow leaf — `CLAUDE.md` records the measurement — so nothing here changes what a leaf sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm2df8R5uJjj3UwDXUerTp

---

## Round 1, and what it changed

Two axes: over-refusal / fit, and claim verification. Both found real defects; the corrections are `929e54a`.

**The over-refusal axis found the rule wrong in the direction this author's rules are always wrong.** The sign asserted "Keeping unless explicitly dropped costs size and nothing else" unconditionally, in a bullet whose own trigger names "an allowlist". Counter-cases in this repository: `_PIPE_TAIL_ALLOWED_IMPORT_ROOTS` excludes `string` because `string.Formatter().get_field()` is a primitive the AST inspector cannot see, so a module nobody considered must fall OUTSIDE it; `validate_workspace_root.py`'s active-status set treats anything outside it, an unreadable meta file included, as not active so leaked scratch is surfaced; and the leaf write roots. All follow `atmofab-enforcement-change` surface 8, which the sentence pointed away from.

**The repair keeps the question and gives up the polarity**: the answer to "would I notice?" decides which default is right, and the sign does not. Where dropping an element produces a REFUSAL, drop-by-default is the loud direction and is correct. A third answer is often best and this repository took it for this exact failure — `_UNSCANNED_ROOT_FILES` makes an unconsidered root file REFUSE until someone decides. The sign now names its two neighbours: it is the selection case of "the same family appeared two rounds running", and inverting a default is a shape change, so the "split into another PR" row applies.

**The claim-verification axis found the episodes were the failure the second rule is about.** I wrote an episode about published numbers going stale and filled it with numbers I had not re-derived. Both episodes are rewritten from the commits and comments. The worst:

| what it said | what the artifacts say |
|---|---|
| "in a file no test reads" | **the exact false statement issue #181 corrected twice** — truncating `TODO.md` reddens `test_hooks_cli::GlobPatternTriggerSurfaceTests` and `test_build_runtime_server::McpCallClientTests` |
| "the two rounds after found five, then fewer" | `cd1ed19`: round 4's blank-slate axis found **no new instance** — the first descent; `6fc605d`: round 5, the cap, found five. Zero then five, and no later round exists |
| "inverting the default is what ended it" | it lowered the rate; the class never reached zero and the loop ended at its cap |
| "rule 3 does not fire here" | it does — its body carries "the place this fires that you will not expect is a CORRECTION", and `measurement-records.md` already states the same rule under issue #153 |
| "a pull request body published a verification script" | the body carried none; the listing was in a COMMENT beside a body quoting its output — which is the actual failure surface |
| "eight completion criteria were selected out" | 14 at `58629e8`, 12 at `a30b6cb`, 14 at `a602046`; and selection did not exist at the commit that lost them |
| "twice passed an item whose loss was a fix direction" | one instance is on the record |
| "three reviewers re-derived" | the record gives inconsistent counts; the episode now states what is checkable |

**The generality claim is bounded now.** Both rules come from one issue. The episode says what a second instance would have to look like and says to read the sign as a question rather than a law until there is one — the form this file already uses for a population of one.

### Convergence

**Not convergence — one round, and its own fixes are unreviewed.** The class did not descend: it was one round. Reversing all three claims in a worktree leaves `test_skill_citations` and `test_development_doc_sync` green, so **review was the only instrument** and a second round would be the only way to find what this one missed. `tools/tests` at `929e54a`: 5891 passed, 3174 subtests, 0 failed — unmoved.