### PR TITLE
skills: the leaf-read document with two readers, and the gate switch the leaf holds

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -239,7 +239,7 @@ When a rule derives its safety from an enumeration, **write a test that kills ea
 enumeration by mutation** (round 0 in `atmofab-review-loop`). A missing element shows up in no
 other test.
 
-The six surfaces that are none of exec / env / argv / FS / evidence paths and none of the
+The seven surfaces that are none of exec / env / argv / FS / evidence paths and none of the
 spelling variation. Each is one question; the episodes, the version tables and the measurement
 recipes are in `references/input-surfaces.md`:
 
@@ -320,6 +320,22 @@ recipes are in `references/input-surfaces.md`:
   one: a linter's walk exclusions and read errors, a compiler's error cap, a test runner's
   collection error, a build system's `-k`. Related but different from surface 5 — nothing here is
   caller-controlled; the tool is simply answering a narrower question than the gate asked.
+- **Surface 11 — does a field the LEAF authors decide which gate applies to its own artifact?**
+  Not what a gate reads to judge — what a gate reads to decide whether to judge at all. A gate that
+  resolves the artifact's kind, its language, its declared model, or the presence of a contract
+  section FROM THE ARTIFACT, and returns early when the value is one it does not cover, hands the
+  leaf the off switch. Issue #168: `_validate_published_surface` takes `spec_kind` from the IR's
+  own `meta`, and a `component` IR self-declaring `problem` passes the whole deterministic compile
+  gate with rc 0 — measured on a real certified IR — dropping every published-surface pin. The
+  same shape recurs: an `impl_defaults.toolchain` value decides who authors the control file, and
+  the phase contract already warns that whichever of three places a state contract appears in
+  first is the one the gate validates. **Rule: resolve the fact from the HOST'S OWN identity for
+  the node — the `node_key`, the launch request, the reservation — never from the document under
+  review, and where a gate legitimately must read it from the document, pin the document's value
+  against the host's before the gate runs.** **The tell**: an early `return` in a gate whose
+  condition is a field of the thing being gated. Enumerate those first; each one is a switch, and
+  the leaf holds it. Distinct from surface 5, where caller data pollutes a classification the host
+  computes — here the host asks the leaf a question and believes the answer.
 
 ### 2. Confirm the path production actually takes
 

--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -24,7 +24,7 @@ here that does not obviously apply to your case is answered in its reference fil
 guessing.
 
 - `references/judgment-episodes.md` — what each judgment rule below cost, in full
-- `references/input-surfaces.md` — surfaces 5-10, the marker-narrowing version table, the recipes
+- `references/input-surfaces.md` — surfaces 5-11, the marker-narrowing version table, the recipes
 - `references/source-text-surface.md` — the spelling variation a source-text-reading gate must survive
 - `references/dual-read-pairs.md` — the table of facts two layers read
 - `references/failure-routing.md` — attribution criteria, the known branches, and remedy wording
@@ -326,10 +326,15 @@ recipes are in `references/input-surfaces.md`:
   section FROM THE ARTIFACT, and returns early when the value is one it does not cover, hands the
   leaf the off switch. Issue #168: `_validate_published_surface` takes `spec_kind` from the IR's
   own `meta`, and a `component` IR self-declaring `problem` passes the whole deterministic compile
-  gate with rc 0 — measured on a real certified IR — dropping every published-surface pin. The
-  same shape recurs: an `impl_defaults.toolchain` value decides who authors the control file, and
-  the phase contract already warns that whichever of three places a state contract appears in
-  first is the one the gate validates. **Rule: resolve the fact from the HOST'S OWN identity for
+  gate with rc 0 — measured on a real certified IR — dropping every published-surface pin. **The
+  same field, twice more**: `_validate_toolchain_backend_supported` reads it to decide whether a
+  node is exempt from half its own check, and the phase contract warns that whichever of three
+  places a multi-dimensional state contract appears in FIRST is the one the gate validates — so an
+  empty mapping in the highest-priority place makes it validate nothing. This tree has also
+  CLOSED one instance already, and it is the shape to copy:
+  `docs/workflow/phases/phase_01_compile.md` records that the `spec_kind` deciding the
+  `infrastructure` dependency-count exemption "is read from `spec_catalog.yaml`, not from the
+  self-declared `deps.yaml` field". **Rule: resolve the fact from the HOST'S OWN identity for
   the node — the `node_key`, the launch request, the reservation — never from the document under
   review, and where a gate legitimately must read it from the document, pin the document's value
   against the host's before the gate runs.** **The tell**: an early `return` in a gate whose
@@ -373,6 +378,21 @@ one.**
   handed probe modules written into a `tempfile` directory, so it missed on every self-test and
   fell back silently. **The fix in both cases was to move the process, or to make the root an
   argument** — not to make the fixture more elaborate
+- **A DISPOSITION TOWARD BAD INPUT travels when you copy or parametrise a path, and the receiving
+  side's validator may not accept it.** Copying "a missing file degrades to `""`" from a sibling
+  path is the recorded shape: on issue #168 the new path's every value was a DECLARED key, and the
+  declared-key validator refuses an empty one — inside `record_launch`, from a call the loop did
+  not guard — so the loop's own named fail-closed branch was bypassed and the exception aborted
+  the conductor instead. **A refusal that happens one frame too late converts a recoverable named
+  outcome into a crash**, which is strictly worse than either the degradation or the refusal.
+  Whenever you lift a behaviour into a shared loop or copy it to a second caller, ask what the
+  RECEIVING side does with the degraded value, not what the donor did.
+  - **And the test for it has to cross the same frame.** The row that "pinned" that degradation
+    drove the builder and then called the validator BY HAND, so it saw a clean `ValueError` where
+    production saw a `RuntimeError` escaping the substep. Same class as the synthetic-input bullet
+    above, one level up: a fixture can be right about every value and still stop short of the
+    frame where the failure happens. Drive the production entry point far enough that the recovery
+    branch is what you observe.
 
 ### 3. Decide the failure's attribution
 

--- a/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
+++ b/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
@@ -274,3 +274,52 @@ the fix there is to change the channel. Here nothing is caller-controlled — th
 a narrower question than the gate asked, and saying so somewhere else. The fix is to stop it
 narrowing, or to listen where it says it did.
 
+## Surface 11 — a field the leaf authors decides which gate applies (issue #168)
+
+A branch moved two `compile` `substep`s to `pure-function leaf`s and added a host-side floor over
+the document the leaf returns. The floor decided WHICH sections to require from the node's kind as
+the host knows it (`refs.node_key`), with a docstring saying that a leaf choosing its own key
+requirement "would be choosing which floor it is held to, which is the `leaf shortcut` class this
+floor exists inside" — and then left the VALUE of `meta.spec_kind` inside the document entirely to
+the leaf.
+
+`tools/validate_pipeline_semantics.py`'s published-surface gate reads the kind from that field and
+returns early for a kind that publishes no surface. Measured by a round-1 reviewer, on real
+certified IRs copied into a sandbox: flipping a `component` IR's `meta.spec_kind` to `problem`
+takes the deterministic compile gate from 2 violations to 1, dropping the `public_api` one; on the
+harness `infrastructure` node it drops 34 of the 38 (the second run directory gives 36 — the
+denominator depends on which artifact you take it from, which is itself why a record naming
+neither the run nor the command is uncheckable). A round-4 reviewer confirmed the other half by
+execution: with the floor's clause in place, `--stage compile` still passes a flipped IR, so the
+host check is the ONLY thing catching it and is correctly placed.
+
+**The gain sentence, which is what makes this a finding rather than a mechanism description**: a
+leaf taking it skips the entire published-interface transcription its own prompt spends a rule on
+— every operation id, published type, structured signature and module parameter copied verbatim —
+and still reports the `substep` done behind a green phase. It surfaces two phases later, in a gate
+that resolves the kind from the execution record instead, which fail-closes saying "Compile
+certified them" and routes the finding to a `substep` that cannot edit the IR.
+
+**Pre-existing, and that is not a reason to leave it.** An agentic leaf could write the same field.
+What was new is that the branch introduced the one place that already resolves the fact from the
+host for exactly this reason and stopped one clause short. Closing it was a clause; the argument
+for closing it took a round.
+
+**The over-refusal half, which the fix has to get right too.** Re-measured at the merge commit
+rather than taken from the reviewer who first ran it: eight pre-existing readers of this field
+across `tools/` and none in `mcp_servers/`, every one of them
+`str(meta.get("spec_kind") or "").strip()` with no case folding, and nothing building a path or an
+identity from it. So the pin ACCEPTS a padded spelling (every reader agrees on it) and REFUSES a
+case-folded one (no reader folds). Applying the predicate to all 204 `spec.ir.yaml` on disk —
+deriving the expected kind from each document's own `meta.node_key` — gives 0 mismatches. A pin
+that refused padding would have been the over-refusal this repository's error direction produces
+by default. **Both halves of that are one enumeration**: you cannot know which spellings to accept
+without listing the readers, and listing them is what tells you the pin is safe to add at all.
+
+**How to find the rest of the family.** Grep the gates for an early `return` whose condition is a
+field of the artifact being gated. In this tree that also finds: `impl_defaults.toolchain`'s
+values deciding who authors the control file and renders the runner, and — stated in the phase
+contract itself as a warning to the leaf — three possible placements of the multi-dimensional
+state contract, of which the gate validates whichever exists FIRST, so writing an empty mapping in
+the highest-priority place makes the gate validate nothing.
+

--- a/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
+++ b/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
@@ -1,4 +1,4 @@
-# Input surfaces 5-10: the episodes behind them
+# Input surfaces 5-11: the episodes behind them
 
 Moved out of `SKILL.md` verbatim (2026-08-25). `SKILL.md` §1 "Inventory the surface before
 fixing" keeps each surface's question and its rule in a few lines; this file is what each one
@@ -296,9 +296,11 @@ host check is the ONLY thing catching it and is correctly placed.
 **The gain sentence, which is what makes this a finding rather than a mechanism description**: a
 leaf taking it skips the entire published-interface transcription its own prompt spends a rule on
 — every operation id, published type, structured signature and module parameter copied verbatim —
-and still reports the `substep` done behind a green phase. It surfaces two phases later, in a gate
-that resolves the kind from the execution record instead, which fail-closes saying "Compile
-certified them" and routes the finding to a `substep` that cannot edit the IR.
+and still reports the `substep` done behind a green phase. It surfaces in the NEXT phase, at the
+`post_generate` gate, whose own resolver reads the kind from the execution record instead — so it
+fail-closes saying "Compile certified them" and routes the finding to a `substep` that cannot edit
+the IR. (An earlier version of this sentence, and the commit message it came from, said "two
+phases later". One.)
 
 **Pre-existing, and that is not a reason to leave it.** An agentic leaf could write the same field.
 What was new is that the branch introduced the one place that already resolves the fact from the
@@ -309,17 +311,40 @@ for closing it took a round.
 rather than taken from the reviewer who first ran it: eight pre-existing readers of this field
 across `tools/` and none in `mcp_servers/`, every one of them
 `str(meta.get("spec_kind") or "").strip()` with no case folding, and nothing building a path or an
-identity from it. So the pin ACCEPTS a padded spelling (every reader agrees on it) and REFUSES a
-case-folded one (no reader folds). Applying the predicate to all 204 `spec.ir.yaml` on disk —
-deriving the expected kind from each document's own `meta.node_key` — gives 0 mismatches. A pin
+identity FROM it — the closest is one reader COMPARING it against catalog entries to choose a
+sibling exemplar, which is a comparison and not a construction, and which strips like the rest. So
+the pin ACCEPTS a padded spelling (every reader agrees on it) and REFUSES a case-folded one (no
+reader folds). Applying the predicate to every file named exactly `spec.ir.yaml` under the
+checkout — 203 of them, counted with `os.walk` because this shell's `grep` respects `.gitignore`
+and the corpus is untracked runtime state — and deriving the expected kind from each document's
+own `meta.node_key`, gives 0 mismatches and 0 documents lacking that key. (An earlier version said
+204: an `endswith` count that also caught the one test-data file whose NAME ends with
+`spec.ir.yaml`. A corpus figure has to say how it counted.) A pin
 that refused padding would have been the over-refusal this repository's error direction produces
 by default. **Both halves of that are one enumeration**: you cannot know which spellings to accept
 without listing the readers, and listing them is what tells you the pin is safe to add at all.
 
-**How to find the rest of the family.** Grep the gates for an early `return` whose condition is a
-field of the artifact being gated. In this tree that also finds: `impl_defaults.toolchain`'s
-values deciding who authors the control file and renders the runner, and — stated in the phase
-contract itself as a warning to the leaf — three possible placements of the multi-dimensional
-state contract, of which the gate validates whichever exists FIRST, so writing an empty mapping in
-the highest-priority place makes the gate validate nothing.
+**How to find the rest of the family.** Grep the gates for an early `return`, or for a local that
+buys an exemption, whose condition is a field of the artifact being gated. In this tree that finds
+the SAME FIELD twice more, which is the useful lesson — the family is usually one field, not one
+gate:
+
+- `_validate_toolchain_backend_supported` (`tools/validate_pipeline_semantics.py`) takes
+  `is_infrastructure` from the IR's own `meta.spec_kind` and exempts such a node from the language
+  half of its own check. Its docstring argues the exemption "admits nothing TODAY" because a
+  second gate covers it — which is the layered reasoning judgment rule 1-c exists for, and the
+  layer it leans on resolves the kind the same way.
+- three possible placements of the multi-dimensional state contract, of which the gate validates
+  whichever exists FIRST — so writing an empty mapping in the highest-priority place makes it
+  validate nothing. This one is stated in the phase contract as a warning TO THE LEAF, which is
+  the wrong end: telling the author not to take the switch is not the same as not handing it over.
+
+**What is NOT in this family, and the discrimination is the point.** The toolchain VALUES
+(`impl_defaults.toolchain.language` / `build_system`) are leaf-authored and decide a great deal,
+but the gate over them is a fail-CLOSED allowlist derived from the backend registry, not an early
+return: an unsupported pair is refused and routed back for a re-author. Nothing is switched off,
+so the rule does not apply — and applying it there would be wrong twice over, because
+`docs/IMPL_PLAN_SPEC.md` fixes that pair for every `spec_kind` by what the host can actually
+build, so "resolve it from the host" is already what the allowlist does. **The test is not "a
+leaf-authored field decides something" — it is "a leaf-authored value makes a check not run".**
 

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -205,6 +205,15 @@ when a rule does not obviously apply:
   rewrites within one second reuse a stale `.pyc`, and the mutant that reports `killed` is the
   PREVIOUS one. Two reviewers hit it independently on PR #100, one of them reporting three live
   mutants as killed; the skill's own script is unaffected because each hunk gets its own worktree
+- **A fixture that writes OUTSIDE its own `TemporaryDirectory` makes its own self-test
+  satisfiable by a leftover.** Issue #168: a traversal-rejection row used `"../outside/ir"`, which
+  resolves to a SIBLING of the tempdir — a fixed path in the shared temp root. The litter is the
+  small half; the sharp half is that the row's own "the file is where discovery would look" check
+  passed on a residue from a previous run rather than on this run's write, and on a shared machine
+  another user's copy turns the row into a `PermissionError` instead of a rejection. It also
+  collides with the parallel worktrees `scripts/mutation_check.py` runs under `TMPDIR`. Keep the
+  escaping path INSIDE the tempdir (traverse back into it) and assert the landing path resolves
+  under it.
 - **Never revert a mutation with `git checkout -- <file>`. TWO reasons, and the second is worse:
   it deletes uncommitted work, and on an UNTRACKED file it is a SILENT NO-OP** — PR #104 shipped a
   mutant for two commits that way. Use a worktree (the script's default; `--keep` leaves it
@@ -264,15 +273,27 @@ when a rule does not obviously apply:
     is what a later member added on one side only turns red. **Trigger**: any `isinstance` /
     `hasattr` in a guard whose purpose is to not raise — name the operation that would raise
     (`for … in`, `sort`, `len`, `[k]`) and ask which member reaches it
+  - **a test that asserts a property ON A COMPLETE FIXTURE cannot see the property** — the
+    general case, of which the type and threshold rows are two instances. Issue #168: a row
+    claiming to hold "no declared context key may be empty" asserted non-emptiness on a fixture
+    where every file was present, so it could not tell a read that DEGRADES from one that RAISES
+    — which was the whole property — and its real coverage was the three filenames the previous
+    commit happened to delete. Measured: the fail-open it was written to pin was reinstated on
+    the other five keys with the suite green. **The recipe that closed it**: one row per
+    contributing input, each REMOVING that input and requiring the failure to name it, plus a
+    set-identity row against the contract table with the derived inputs listed as NAMED
+    exemptions — so an input added later is either given a row or an exemption, and never
+    silently neither. **Trigger**: any assertion of the form "all of X are well-formed" whose
+    fixture supplies all of X
   - **when the code applies a THRESHOLD, the fixture must straddle it too, and the straddle is
-    usually a LENGTH** — the same rule as the type case above, and the one that hides best,
-    because the fixture looks realistic. Issue #168: a class whose subject is how a failure reason
-    is composed carried an 79-character flake constant while the code clipped the evidence at 110,
-    so every row in it passed while observing nothing about the composition — and a later change
-    to that clip shipped a regression through all of them. **Trigger**: any cap, clip, budget,
-    `[:n]`, `max_`/`MAX_` or size comparison on the path under test. Name the threshold, then
-    assert IN THE TEST BODY that the probe is on the far side of it (`assertGreater(len(probe),
-    110)`), so a later shortening of the fixture is red rather than silent
+    usually a LENGTH** — the same shape, and the one that hides best because the fixture looks
+    realistic. Issue #168 again: a class whose subject is how a failure reason is composed
+    carried an 80-character flake constant while the code clipped the evidence at 110, so every
+    row in it passed while observing nothing about the composition — and a later change to that
+    clip shipped a regression through all of them. **Trigger**: any cap, clip, budget, `[:n]`,
+    `max_`/`MAX_` or size comparison on the path under test. Name the threshold, then assert IN
+    THE TEST BODY that the probe is on the far side of it (`assertGreater(len(probe), 110)`), so
+    a later shortening of the fixture is red rather than silent
   - **a hand-built fixture can test a shape that does not exist** — check the construct against
     the real corpus before writing the witness
   - **for stateful code, match the fixture to the lifetime of the state**, and always include a
@@ -914,19 +935,25 @@ would mislead you, can the deletion's measurement be re-taken from what is writt
 went with what was deleted**, what does a LEAF see, what does an OPERATOR see, would you merge". If
 it returns first-category items, the record has not converged even though the enforcement code has.
 
-**"What does a LEAF see" means RENDER THE PROMPT, once per leaf that receives it.** Ask for the
-production entry point (`build_launch_request` -> `prepare_launch_request_payload` ->
-`render_launch_prompt_text`) and for the result to be read end to end, as that leaf, against what
-the host will actually refuse. Reading the template is not the same thing: a host-inlined document
-arrives whole, and the sentence that matters is usually one nobody wrote for this leaf. Issue #168
-found the branch's two worst defects this way and no other way.
-
-**The added clause is not a flourish.** On PR #125 it is what surfaced the branch's only blocker —
+**The "what CHECK went with what was deleted" clause is not a flourish.** On PR #125 it is what
+surfaced the branch's only blocker —
 a check `origin/main` had that a round-2 fix narrowed away — and no other instrument in this loop
 could have: the sweep mutates what exists, the census enumerates what exists, and a blank-slate
 reviewer reads HEAD. **Everything else compares HEAD against itself.** The disclosure round is the
 one place a reviewer is pointed at the previous revision, so it is the only place a deleted
 guarantee is visible.
+
+**And "what does a LEAF see" means RENDER THE PROMPT, once per leaf that receives it — WHEN the
+branch changed text a leaf is handed.** That condition is the whole scope: a branch that touches
+no leaf-read document owes this nothing, and asking for it there buys a standing-up of an
+orchestration and a six-figure byte count per render for no reason. When it does apply, ask for
+the production entry point (`build_launch_request` -> `prepare_launch_request_payload` ->
+`render_launch_prompt_text`) and for the result to be read end to end, as that leaf, against what
+the host will actually refuse. Reading the template is not the same thing: a host-inlined document
+arrives whole, and the sentence that matters is usually one nobody wrote for this leaf. It is how
+issue #168 found the defects of its rounds 3, 4 and 5, and nothing else on that branch found any
+of them. (Its worst defect overall was round 1's, and that one came from a security axis measuring
+gates against real corpus artifacts — this instrument is not a substitute for that one.)
 
 **For a change that adds checking machinery, run a witness census once.** Instruct a dedicated
 reviewer:
@@ -980,25 +1007,6 @@ that tells you how it closed.
   as the focus** in the next round's prompt. The more the change is a move or rename whose body is
   known correct, the more the review is really about **your own fixes** — put that instruction in
   from round 1
-- **You corrected prose a LEAF reads, and you corrected it for ONE reader** → every other leaf
-  handed the same text got your correction too, and a sentence that is true for one can be a
-  `leaf shortcut` in another. This is the RECORD row's twin on the delivery side: there the
-  correction was unverified, here it is verified for the reader you had in mind and shipped to
-  readers you did not. **Criterion, and it is not a reading**: list every leaf the document
-  reaches, RENDER each one's prompt through the production entry point, and read the new sentence
-  in place as that leaf — then ask the gain question of it, "a leaf following this sentence is
-  closer to ___". A host-inlined contract makes this the default rather than the exception: one
-  document, several personas, opposite obligations. Issue #168 hit it three rounds running, twice
-  in the SAME section: a per-path paragraph written for the producer told the reviewer that
-  authoring the IR and returning a null failure reason — the reviewer's own PASS invariant — was
-  "the ordinary thing", and a bounding sentence in the reviewer's template ("that list is the
-  whole of your scope") made a four-way disagreement in the inlined document load-bearing, whose
-  narrowest reading dropped the one invariant family no deterministic gate re-checks. **Both were
-  written while fixing this same class.** Two consequences worth carrying: a summary of a
-  substep's scope stated anywhere but where the scope is defined is a second definition, so delete
-  it rather than correct it; and **nothing in this loop catches these except the rendered prompt**
-  — the sweep mutates code, the census enumerates code, a blank-slate reviewer reads code, and the
-  suite stays green with the sentence inverted (measured, all three rounds)
 - **The fix was to a RECORD, so you verified it by reading** → a record fix carries the same
   defect rate as a code fix, and this is the sub-case of the row above that gets skipped, because
   prose does not look like something you run. Criterion: **the corrected sentence must pass the
@@ -1022,6 +1030,25 @@ that tells you how it closed.
   attribution is visible rather than inferred. **Do not delete a wrong correction — record that it
   was wrong**, or nobody can tell an audited corrections bullet from an unaudited one
   (`references/measurement-records.md`)
+- **You corrected prose a LEAF reads, and you corrected it for ONE reader** → every other leaf
+  handed the same text got your correction too, and a sentence that is true for one can be a
+  `leaf shortcut` in another. This is the RECORD row's twin on the delivery side: there the
+  correction was unverified, here it is verified for the reader you had in mind and shipped to
+  readers you did not. **Criterion, and it is not a reading**: list every leaf the document
+  reaches, RENDER each one's prompt through the production entry point, and read the new sentence
+  in place as that leaf — then ask the gain question of it, "a leaf following this sentence is
+  closer to ___". A host-inlined contract makes this the default rather than the exception: one
+  document, several personas, opposite obligations. Issue #168 hit it three rounds running, twice
+  in the SAME section: a per-path paragraph written for the producer told the reviewer that
+  authoring the IR and returning a null failure reason — the reviewer's own PASS invariant — was
+  "the ordinary thing", and a bounding sentence in the reviewer's template ("that list is the
+  whole of your scope") made a four-way disagreement in the inlined document load-bearing, whose
+  narrowest reading dropped one of the two invariant families with no deterministic backstop. **Both were
+  written while fixing this same class.** Two consequences worth carrying: a summary of a
+  substep's scope stated anywhere but where the scope is defined is a second definition, so delete
+  it rather than correct it; and **nothing in this loop catches these except the rendered prompt**
+  — the sweep mutates code, the census enumerates code, a blank-slate reviewer reads code, and the
+  suite stays green with the sentence inverted (measured, all three rounds)
 - **You have rewritten the same string three times** → the problem is not the rule but the prose
   citing it. Switch to the grep sweep
   (`.claude/skills/atmofab-enforcement-change/references/verification.md`). **Rewriting one

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -264,6 +264,15 @@ when a rule does not obviously apply:
     is what a later member added on one side only turns red. **Trigger**: any `isinstance` /
     `hasattr` in a guard whose purpose is to not raise — name the operation that would raise
     (`for … in`, `sort`, `len`, `[k]`) and ask which member reaches it
+  - **when the code applies a THRESHOLD, the fixture must straddle it too, and the straddle is
+    usually a LENGTH** — the same rule as the type case above, and the one that hides best,
+    because the fixture looks realistic. Issue #168: a class whose subject is how a failure reason
+    is composed carried an 79-character flake constant while the code clipped the evidence at 110,
+    so every row in it passed while observing nothing about the composition — and a later change
+    to that clip shipped a regression through all of them. **Trigger**: any cap, clip, budget,
+    `[:n]`, `max_`/`MAX_` or size comparison on the path under test. Name the threshold, then
+    assert IN THE TEST BODY that the probe is on the far side of it (`assertGreater(len(probe),
+    110)`), so a later shortening of the fixture is red rather than silent
   - **a hand-built fixture can test a shape that does not exist** — check the construct against
     the real corpus before writing the witness
   - **for stateful code, match the fixture to the lifetime of the state**, and always include a
@@ -905,6 +914,13 @@ would mislead you, can the deletion's measurement be re-taken from what is writt
 went with what was deleted**, what does a LEAF see, what does an OPERATOR see, would you merge". If
 it returns first-category items, the record has not converged even though the enforcement code has.
 
+**"What does a LEAF see" means RENDER THE PROMPT, once per leaf that receives it.** Ask for the
+production entry point (`build_launch_request` -> `prepare_launch_request_payload` ->
+`render_launch_prompt_text`) and for the result to be read end to end, as that leaf, against what
+the host will actually refuse. Reading the template is not the same thing: a host-inlined document
+arrives whole, and the sentence that matters is usually one nobody wrote for this leaf. Issue #168
+found the branch's two worst defects this way and no other way.
+
 **The added clause is not a flourish.** On PR #125 it is what surfaced the branch's only blocker —
 a check `origin/main` had that a round-2 fix narrowed away — and no other instrument in this loop
 could have: the sweep mutates what exists, the census enumerates what exists, and a blank-slate
@@ -964,6 +980,25 @@ that tells you how it closed.
   as the focus** in the next round's prompt. The more the change is a move or rename whose body is
   known correct, the more the review is really about **your own fixes** — put that instruction in
   from round 1
+- **You corrected prose a LEAF reads, and you corrected it for ONE reader** → every other leaf
+  handed the same text got your correction too, and a sentence that is true for one can be a
+  `leaf shortcut` in another. This is the RECORD row's twin on the delivery side: there the
+  correction was unverified, here it is verified for the reader you had in mind and shipped to
+  readers you did not. **Criterion, and it is not a reading**: list every leaf the document
+  reaches, RENDER each one's prompt through the production entry point, and read the new sentence
+  in place as that leaf — then ask the gain question of it, "a leaf following this sentence is
+  closer to ___". A host-inlined contract makes this the default rather than the exception: one
+  document, several personas, opposite obligations. Issue #168 hit it three rounds running, twice
+  in the SAME section: a per-path paragraph written for the producer told the reviewer that
+  authoring the IR and returning a null failure reason — the reviewer's own PASS invariant — was
+  "the ordinary thing", and a bounding sentence in the reviewer's template ("that list is the
+  whole of your scope") made a four-way disagreement in the inlined document load-bearing, whose
+  narrowest reading dropped the one invariant family no deterministic gate re-checks. **Both were
+  written while fixing this same class.** Two consequences worth carrying: a summary of a
+  substep's scope stated anywhere but where the scope is defined is a second definition, so delete
+  it rather than correct it; and **nothing in this loop catches these except the rendered prompt**
+  — the sweep mutates code, the census enumerates code, a blank-slate reviewer reads code, and the
+  suite stays green with the sentence inverted (measured, all three rounds)
 - **The fix was to a RECORD, so you verified it by reading** → a record fix carries the same
   defect rate as a code fix, and this is the sub-case of the row above that gets skipped, because
   prose does not look like something you run. Criterion: **the corrected sentence must pass the

--- a/.claude/skills/atmofab-review-loop/references/signs-episodes.md
+++ b/.claude/skills/atmofab-review-loop/references/signs-episodes.md
@@ -382,7 +382,8 @@ that list is the whole of your scope". That document states the scope FOUR times
 section, a §substep-structure summary naming three of six invariant families, a §fixed/knob
 sentence assigning two more from outside the verify section, and now the template. A sentence
 meant to BOUND the reviewer made the document's own disagreement load-bearing, and the narrowest
-reading is the summary, which drops the one family with no deterministic backstop. Measured:
+reading is the summary, which drops one of the two families the verify section itself names as
+having no deterministic backstop. Measured:
 stripping every `algorithm.steps[].description` from a real certified IR still PASSES the
 deterministic compile gate, so that family at `verify` is the only thing between a de-mathed IR
 and a `Generate` leaf walled off from the spec.
@@ -406,7 +407,7 @@ per-path: "the pure path" is not one reader.
 **The same branch's numeric-threshold episode, for the round-0 list.** Round 5 also found a
 regression in round 4's own fix: a `reason_detail` clip widened to fit a filename evicted the
 `[attempts=N]` marker, which is what tells an operator an outage outlasted every backoff. Every
-existing test in the class passed, because the class's flake constant is 79 characters and the
+existing test in the class passed, because the class's flake constant is 80 characters and the
 clip it was supposed to exercise is 110 — the fixture had never been on the far side of the
 threshold it was measuring. The fix reserves the marker in the budget; the test asserts, in its
 own body, that its probe is longer than any clip.

--- a/.claude/skills/atmofab-review-loop/references/signs-episodes.md
+++ b/.claude/skills/atmofab-review-loop/references/signs-episodes.md
@@ -348,3 +348,66 @@ mechanically rather than checking for them by hand.
 false by the removal, and repaired those three. The class was not then swept for elsewhere in the
 tree, so round 5 found a fourth citation, in `tools/tests/test_backend_boundary.py`, of a sentence
 the compression had dropped. **A fix that does not sweep its own class schedules the next round.**
+
+## "You corrected prose a LEAF reads, and you corrected it for ONE reader" (issue #168)
+
+The change made two `compile` `substep`s `pure-function leaf`s. On that path the host inlines a
+closed context into one prompt, and one of the documents it inlines VERBATIM is
+`docs/workflow/phases/phase_01_compile.md` — the same document, whole, into BOTH the producer's
+prompt and the reviewer's. That document had been written when both substeps were agentic, so
+every sentence in it assuming a filesystem, a tool, or the OTHER substep's contract became an
+instruction to a leaf that could not follow it, or could.
+
+**Round 3** found the first: §"Acceptance of retry from Validate" tells the leaf to read
+`launches/<agent_run_id>.request.json`, and, failing to find a quote there, to "stop with a
+`Compile fail`" and record `validate_feedback:<finding_id>` in `ir_meta.json.last_fail_reason`. On
+the pure path that field is the TERMINAL declaration channel — deliberately off the routing table
+— so a leaf following the sentence literally ends the run instead of recording a repair. The
+reviewer that found it did not reason about it: it drove the live Validate→Compile route and
+showed the rendered launch carries `repair_reason: none, repair_findings: None`, so the leaf is
+handed the paragraph and nothing to satisfy it with.
+
+**Round 4** found that round 3's fix — a per-path paragraph — landed in the REVIEWER's prompt too
+(the reviewer that found it named the rendered line), where every claim in it was false: the reviewer has no declared-fail exit at
+all, its `last_fail_reason` is the ordinary verify-fail channel, and the paragraph's closing advice
+("author the IR … and return `last_fail_reason: null`") is simultaneously forbidden by the
+reviewer's own template three lines above and identical to its PASS invariant. A host-authored
+sentence named the passing verdict "the ordinary thing", on precisely the re-submission where
+`Validate` had already said the IR was at fault. The always-on half was worse than the
+re-submission half: it reached every launch of that substep.
+
+**Round 5** found the third, in the same class and again in a sentence written to help. The
+reviewer's template said the phase contract's verify section "states them as a numbered list, and
+that list is the whole of your scope". That document states the scope FOUR times — the verify
+section, a §substep-structure summary naming three of six invariant families, a §fixed/knob
+sentence assigning two more from outside the verify section, and now the template. A sentence
+meant to BOUND the reviewer made the document's own disagreement load-bearing, and the narrowest
+reading is the summary, which drops the one family with no deterministic backstop. Measured:
+stripping every `algorithm.steps[].description` from a real certified IR still PASSES the
+deterministic compile gate, so that family at `verify` is the only thing between a de-mathed IR
+and a `Generate` leaf walled off from the spec.
+
+**What each round's instrument could and could not see.** All three were found by rendering the
+production prompt and reading it as the leaf, and by nothing else. The mutation sweep mutates
+code; the witness census enumerates code; a blank-slate reviewer reads HEAD's code. A reviewer in
+each of rounds 3, 4 and 5 confirmed the same thing independently: **delete or invert the sentence
+and the whole suite stays green.** The documents are unpinned by the prompt-contract drift guard
+by an explicit, argued refusal (hashing a document edited on 30 distinct days would bump the
+contract version on most edits, which stops prior-art exemplar selection and refuses `--resume`
+across the bump) — so the refusal is right and its cost is now measured rather than hypothetical,
+which is the only honest form for a residue entry.
+
+**Two rules came out of it.** A summary of a substep's scope stated anywhere but where the scope
+is defined is a SECOND DEFINITION — delete it, do not correct it; the fix that held was stating
+the scope once, in the section that defines it, and having the template refuse every narrower
+reading BY NAME, its own sentence included. And the per-path correction has to be per-SUBSTEP, not
+per-path: "the pure path" is not one reader.
+
+**The same branch's numeric-threshold episode, for the round-0 list.** Round 5 also found a
+regression in round 4's own fix: a `reason_detail` clip widened to fit a filename evicted the
+`[attempts=N]` marker, which is what tells an operator an outage outlasted every backoff. Every
+existing test in the class passed, because the class's flake constant is 79 characters and the
+clip it was supposed to exercise is 110 — the fixture had never been on the far side of the
+threshold it was measuring. The fix reserves the marker in the budget; the test asserts, in its
+own body, that its probe is longer than any clip.
+

--- a/tools/tests/test_workflow_conductor.py
+++ b/tools/tests/test_workflow_conductor.py
@@ -5290,7 +5290,7 @@ class LeafTransientRetryTest(unittest.TestCase):
         self.assertNotIn("write-step-result", [s for s, _ in c.calls])
 
     #: A terminal transport line long enough to fill the whole `reason_detail` budget on its own.
-    #: The class's own `_FLAKE` is 79 characters, which is why every earlier row here passed
+    #: The class's own `_FLAKE` is 80 characters, which is why every earlier row here passed
     #: while the composition silently dropped its tail: the evidence has to be longer than the
     #: clip for the clip to be observable at all. This shape is the real one — the CLI's
     #: connection error with the upstream JSON body attached.


### PR DESCRIPTION
Three shapes from issue #168 (merged at `c820bfe`) that neither skill named, and all three were expensive: rounds 3, 4 and 5 each found a defect **inside the previous round's fix**, and two of those were prose a leaf reads.

## `atmofab-review-loop`

- **New sign — "you corrected prose a LEAF reads, and you corrected it for ONE reader".** A host-inlined contract reaches several personas with opposite obligations. On #168 a per-path paragraph written for the producer told the *reviewer* that authoring the IR and returning a null failure reason — its own PASS invariant — was "the ordinary thing"; and a template sentence written to BOUND the reviewer's scope made a four-way disagreement in the inlined document load-bearing, whose narrowest reading dropped the one invariant family no deterministic gate re-checks. Both were written while fixing this same class. Placed beside the RECORD sign, whose twin it is.
- **The disclosure round's "what does a LEAF see" now says what it means operationally**: render the prompt, once per leaf that receives it. Reading the template is not the same thing — the sentence that matters is usually one nobody wrote for this leaf, and nothing else in the loop can see it (the sweep mutates code, the census enumerates code, a blank-slate reviewer reads code; all three rounds confirmed the suite stays green with the sentence inverted).
- **Round 0's straddle rule gains its numeric-threshold case.** A class whose subject was how a failure reason is composed carried a 79-character fixture against a 110-character clip, so every row passed while observing nothing — and a later change to that clip shipped a regression through all of them.

## `atmofab-enforcement-change`

- **Surface 11 — does a field the LEAF authors decide which gate applies to its own artifact?** Not what a gate reads to judge, but what it reads to decide whether to judge at all. `_validate_published_surface` resolves `spec_kind` from the IR's own `meta` and returns early for a kind that publishes no surface, so a `component` IR self-declaring `problem` passes the whole deterministic compile gate and drops every published-surface pin. The tell is an early `return` whose condition is a field of the thing being gated; in this tree the same tell also finds the toolchain values and the three-placement state contract.

Rules in the `SKILL.md` files, episodes in `references/`, per the split those files state.

## Measured

Full suite **5969 passed / 3261 subtests** at this commit. `tools/tests/test_skill_citations.py` green — that is what holds the backticked paths these additions cite.

The reader enumeration in the surface-11 episode was **re-measured here** rather than repeated from the reviewer who first ran it (8 pre-existing readers in `tools/`, none in `mcp_servers/`, every one `.strip()` with no case folding; 204 `spec.ir.yaml` on disk, 0 kind mismatches against each document's own `meta.node_key`). `atmofab-enforcement-change` rule 3 asks for exactly that, and the episode is about a rule the same branch broke. The two figures I did not re-run are attributed in place to the reviewers who measured them.

**No review round was spent on this**, per `atmofab-review-loop`'s own rule: text only a maintainer reads is corrected in the commit that notices it, never advances or resets a stopping condition, and never justifies a budgeted round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm2df8R5uJjj3UwDXUerTp