### PR TITLE
skills: the surface a transport change opens, and the staging trap that is not about folding

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -239,7 +239,7 @@ When a rule derives its safety from an enumeration, **write a test that kills ea
 enumeration by mutation** (round 0 in `atmofab-review-loop`). A missing element shows up in no
 other test.
 
-The seven surfaces that are none of exec / env / argv / FS / evidence paths and none of the
+The eight surfaces that are none of exec / env / argv / FS / evidence paths and none of the
 spelling variation. Each is one question; the episodes, the version tables and the measurement
 recipes are in `references/input-surfaces.md`:
 
@@ -341,6 +341,29 @@ recipes are in `references/input-surfaces.md`:
   condition is a field of the thing being gated. Enumerate those first; each one is a switch, and
   the leaf holds it. Distinct from surface 5, where caller data pollutes a classification the host
   computes — here the host asks the leaf a question and believes the answer.
+- **Surface 12 — when you change how a leaf is DRIVEN, what stops being delivered to it?** The
+  other eleven ask what an input decides. This one asks what a TRANSPORT carries, and it is
+  invisible from the diff: moving a leaf from the agentic loop to the pure one deletes its
+  `skill_must_read_refs` wholesale, so **every force-read document it had is silently cut**, and
+  a rule that reached it only that way is now enforced by a gate and stated to nobody. Issue #169
+  cut `docs/workflow/CHECKS_MODULE_CONTRACT.md` §5 — the deterministic lint/syntax rule set for
+  leaf-authored source — off the one leaf whose runner it was written for, while
+  `leaf_contract_doc_refs`' own docstring names that leaf as the reason not to gate the injection
+  on node shape. **Rule: before changing a leaf's transport, enumerate what the OLD transport
+  delivered — the SKILL, each `leaf_contract_doc_refs` entry, each must-read the request built —
+  and say for each where it goes now.** Three answers are legitimate (inlined as context,
+  restated in the template, genuinely not needed) and a fourth is the defect (nowhere). **The
+  tell is that nothing fails**: the gate still runs, the suite is green, and the cost is a leaf
+  that cannot satisfy a rule it was never shown — a pass-rate defect that reads as model
+  weakness — and the count you quote has to say what it counted: measured at issue #169's round-3
+  commit, the leaf's prompt named NONE of the seven rule codes by code and carried three of the
+  seven obligations in prose. **Where the cut document is BACKEND knowledge, restating it in the
+  template is the one option `docs/BACKEND_BOUNDARY.md` forbids** (a new neutral-core file starts
+  at zero, so any such token is growth); deliver it from the backend package through the registry
+  instead, which is where that rule says the knowledge already lives.
+  **Nothing in this repository's review loop finds this except rendering the prompt** — the
+  mutation sweep mutates code, the census enumerates code, a blank-slate reviewer reads code, and
+  all three were green on it; see `atmofab-review-loop`'s "what does a LEAF see" clause.
 
 ### 2. Confirm the path production actually takes
 

--- a/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
+++ b/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
@@ -1,4 +1,4 @@
-# Input surfaces 5-11: the episodes behind them
+# Input surfaces 5-12: the episodes behind them
 
 Moved out of `SKILL.md` verbatim (2026-08-25). `SKILL.md` §1 "Inventory the surface before
 fixing" keeps each surface's question and its rule in a few lines; this file is what each one
@@ -348,3 +348,62 @@ so the rule does not apply — and applying it there would be wrong twice over, 
 build, so "resolve it from the host" is already what the allowlist does. **The test is not "a
 leaf-authored field decides something" — it is "a leaf-authored value makes a check not run".**
 
+## Surface 12 — changing a leaf's transport deletes its force-read set (issue #169)
+
+The episode. Issue #169's PR-3 moved the `infrastructure` harness self-test's two `Generate`
+leaves from the shared agentic loop to the pure one. The diff is about a bundle SHAPE: a new
+`runner` role, a `shape` argument on the acceptance contract, twin readers deciding which node
+gets which. Nothing in it mentions a document.
+
+But `build_launch_request` empties `skill_must_read_refs` for a pure launch, so the move deleted
+every force-read that leaf had. One of them was `docs/workflow/CHECKS_MODULE_CONTRACT.md` §5,
+which is the deterministic `Generate.gate` lint and syntax rule set for leaf-authored source and
+says of itself that it applies to "the hand-authored runner of an `infrastructure` node's
+self-test" — that leaf, named. `orchestration_runtime.leaf_contract_doc_refs`' docstring is
+sharper still: "the non-M3c leaf that hand-authors its own runner is the one with ABI-fixed
+unused dummies. Do NOT gate this injection on `is_m3c_physics`." The change gated it on
+something stronger than node shape — on the transport — and no reader of either sentence would
+have predicted that.
+
+**What made it invisible.** The prompt template had been written language-NEUTRAL on purpose,
+because a new file under `tools/prompt_templates/` starts at zero in the backend-boundary
+baseline and `AGENTS.md` forbids growth. So the template could not restate the rules, and the
+author (me) recorded that as a known cost in the commit message — while believing the rules
+still reached the leaf through the document. They did not. Both halves were true and the
+conjunction was the defect.
+
+**What each instrument said.** The round-0 mutation sweep: clean. Two rounds of security and
+correctness axes with their own mutants: clean on this. A Codex pass: clean. A witness census:
+clean. All correct — there is no mutant for a document that is not delivered, and no test
+asserts the absence of an absence. The disclosure axis found it in one step by RENDERING the
+production prompt and looking for the rule set in it.
+
+Re-measured here at `107d946`, because the first version of this paragraph quoted the reviewer's
+count and the count depends on what you look for. By CODE: the m3c producer's template names all
+seven of `C011 C072 C121 C122 C131 PORT011 S001`; the harness prompt, §5 included, named **none**
+— §5 states obligations without their codes. By OBLIGATION: §5 covers three (the column limit,
+the `only:` import form, the assumed-length `intent(out)` character dummy) and is silent on the
+other four. Either way the leaf was held to rules no document it received stated; the two numbers
+answer different questions, and quoting one without saying which is how a measurement rots.
+
+**The enumeration that would have caught it**, and it is cheap — under a minute against the
+code:
+
+1. what SKILL did the old transport deliver, and does anything replace it;
+2. what does `leaf_contract_doc_refs` return for this `(step, is_m3c_physics)`, entry by entry;
+3. what did `build_launch_request` append to `must_read` on this branch;
+4. for each, one of: inlined as a `pure_context` document / restated in the template / genuinely
+   not needed for this leaf / **nowhere** — and the fourth is the finding.
+
+**The fix's own trap, recorded because it took two more rounds.** Inlining §5 restored three of
+the seven codes; the other four are in the linter's rule set and in no document at all. The
+template could not carry them (boundary), so they came from the linter BACKEND — a
+`lint_rules_document()` composed from `RULE_CODES`, reached through a `lint_rules` capability
+declared by the one backend that implements it. Two things went wrong on the way and both are
+general: the first version asked `capability_module` for `lint`, which every registered linter
+declares because they all RUN, so the dispatch fell through to a `getattr` for five of eight
+languages — the exact shape `capability_module` exists to prevent, and it needed a capability of
+its own to become a registry refusal. And the prompt sentence introducing the new section said
+the inlined document "is" the gate's rule set, which it was not: a rule that overclaims
+completeness sends the leaf away from the rest. **When you deliver a rule set to a leaf, state
+what it does NOT cover in the same sentence.**

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -63,6 +63,24 @@ the same defect again in the document, as a `leaf shortcut` on the other transpo
 line in a message cost a whole round.** Read the stat, and name every file, especially the ones you
 edited as an afterthought — those are exactly the copies.
 
+**The trigger that actually fires is ONE FILE EDITED FOR TWO FINDINGS, and the two rules above
+read as if it is not.** They are written for a FOLDED commit — one you chose to make wide — so
+neither comes to mind while you are splitting properly. Issue #169 broke it twice in one loop
+while following both: the fixes for two findings landed in one file, `git add <that file>` swept
+the second finding's work into the first finding's commit, and the message described work that
+was not there while the next commit claimed work already committed. Nothing detects it, because
+both commits are individually coherent and the suite is green either way. **The rule is
+mechanical and belongs before `git add`, not before the message: when a round touched a file for
+more than one finding, stage that file with `git add -p` or commit the findings in the order the
+file was edited.** And read the stat BEFORE writing the message rather than after — writing it
+first and staging second is how a correct-looking message gets attached to the wrong diff.
+
+**When it has already happened and the commit is pushed or built on, do not rewrite history to
+tidy it** — say in the later commit which finding's work is in which commit, and why. A reader
+looking for a witness needs the pointer more than the history needs to be neat; and give them a
+SHA that resolves, since an amended commit leaves a dangling one that looks fine locally and
+exists in no clone.
+
 **`git commit --amend` for a message-only fix requires an empty index** (or `--only`); it
 silently absorbs whatever is staged (PR #58: an amend swallowed a file replacement, leaving a
 commit that claims work `git log -S` cannot find). **If it is unpushed you can fix it by

--- a/.claude/skills/atmofab-review-loop/references/round-conduct.md
+++ b/.claude/skills/atmofab-review-loop/references/round-conduct.md
@@ -46,6 +46,29 @@ file the round does not attack** — so the omission did not merely misdescribe 
 a second round at the price of the first. The afterthought edits are the dangerous ones precisely
 because they are where a rule gets COPIED.
 
+**The narrower trigger, measured on issue #169: one file edited for TWO findings in one round.**
+Twice in that loop the message was wrong, both times while splitting one commit per finding — so
+the folded-commit framing above never fired. The mechanism is dull, and both instances are
+checkable at the commits named. Round 2: `tools/tests/test_pure_leaf_producer.py` carried the
+repair-lift rows AND the tamper gate's fail-closed-default row; `git add` on that path put both
+in `6531bc1`, whose message describes only the first, while `6439198`'s message claims the second
+(`git show 6531bc1 -- tools/tests/test_pure_leaf_producer.py | grep -c shapeless_node` -> 1).
+Round 3, wider: `test_pure_leaf_verify.py`, `tools/workflow_conductor.py` and
+`test_pure_leaf_producer.py` each carried work for the round's blocker AND for a separate
+finding, so `21d2303` absorbed all three and `107d946` describes them (`git show 21d2303 --
+tools/workflow_conductor.py | grep -c "no CodegenBundle shape"` -> 2). Both commits were
+individually coherent, both suites green, and the only reader who would ever notice is one going
+to look for a specific witness — which is exactly the reader a review loop writes commit messages
+for.
+
+Two consequences worth separating. The mechanical one: **the guard belongs before `git add`, not
+before the message** — `git add -p` for a file two findings touched, or commit in the order the
+file was edited. The recovery one: once it is committed, **do not rewrite history to tidy it**.
+Both instances were recorded in the following commit instead, which is right; but the first
+recovery cited a SHA from an amended commit, and a dangling pre-amend SHA resolves in the local
+repository and in no clone — so a reader sent there finds nothing. Cite the commit that is on the
+branch, and check it with `git merge-base --is-ancestor <sha> HEAD` before writing it down.
+
 **`git commit --amend` for a message-only fix requires an empty index** (or pass `--only`).
 `--amend` silently absorbs whatever is staged. In PR #58 an `--amend` meant to fix one false
 sentence swallowed a file replacement that happened to be staged, leaving **a commit that


### PR DESCRIPTION
Two additions from issue #169's PR-3 review loop (PR #197), each a trap the existing text did not fire on.

## Surface 12 — changing how a leaf is DRIVEN deletes what is DELIVERED to it

`atmofab-enforcement-change`. The other eleven surfaces ask what an input decides; this one asks what a **transport** carries. Moving a leaf from the agentic loop to the pure one empties `skill_must_read_refs`, so every force-read document it had is cut — and a rule that reached it only that way is enforced by a gate and stated to nobody.

#169 cut `docs/workflow/CHECKS_MODULE_CONTRACT.md` §5 off the one leaf its own text names, while `leaf_contract_doc_refs`' docstring says not to gate that injection on node shape. The change gated it on something stronger.

**The tell is that nothing fails**: gate green, suite green, and the cost is a leaf that cannot satisfy a rule nobody showed it — a pass-rate defect that reads as model weakness. The rule is an enumeration to run *before* the transport change, with four answers per entry, three legitimate and the fourth (nowhere) the finding.

The episode file records what each instrument said, because they were all **correct and all silent**: there is no mutant for a document that is not delivered, and no test asserts the absence of an absence. Only rendering the prompt found it.

## The staging trap — narrower than the rule that was supposed to catch it

`atmofab-review-loop`. "Read `git show --stat` before writing the message" and "name every file" are written for a **folded** commit, so neither comes to mind while splitting one commit per finding — which is when this fires. The trigger: one file edited for **two findings** in one round, then `git add <path>`. The guard belongs before `git add`, not before the message.

## Corrections made while writing this

Two of the three are the point — a measurement quoted from the review that raised it is not a measurement:

- The reviewer's "seven codes in the m3c prompt, three in the harness one" re-measures, at `107d946`, to seven vs **none** by code (§5 states obligations without their codes) and three of seven by obligation. The text now says which it counted.
- My first draft of the staging episode named the wrong file/finding pair. Re-derived from git; it now cites two commands a reader can run.
- `SKILL.md` said "The seven surfaces". It is eight. The reference title moved 5-11 → 5-12 with it — the skill's own rule 3-a turned on itself.

One mid-edit repair is recorded in the commit message: a second `str.replace` on one paragraph ate three words, caught by re-reading the file after the write, which is the rule the skill already carries.

`test_skill_citations` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm2df8R5uJjj3UwDXUerTp