### PR TITLE
skills: relocating a fact, surface 12's mirror, and four traps a coupling check has

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -57,6 +57,17 @@ a fail-open that way, on the strength of **one** compiler probe).
   you write it, execute one case from that spec and confirm.** What breaks these claims is always
   the language's **special form** (PEP 420 namespace packages, use association, implicit
   association rules). Any "impossible" about package structure, scope, or visibility gets one run
+- **MOVING a fact is deleting a defense you never classified**, and it is the one shape here that
+  reaches no classification at all, because nothing prompts you to make one: the check still
+  runs, still passes, and now covers less. Issue #175 moved the adopted `profile` out of the
+  sidecar's `all_nodes` into a key of its own, and `_closure_signature` — the R6-lite freshness
+  comparison — reads `all_nodes`; so bumping a profile's version left every adopter byte-identical
+  at the new HEAD and CHANGED it on `origin/main`, where the profile had been an ordinary node.
+  **Rule: before moving a fact between structures, list the readers of the OLD structure and say
+  for each what it sees now.** The tell is a diff that ADDS a key rather than changing a value —
+  nothing looks removed. Nothing in a review loop finds this except comparing the two revisions,
+  which is why it is `atmofab-review-loop`'s disclosure axis that caught it and not the sweep, the
+  census, or a blank-slate reviewer, all of which compare HEAD against itself
 
 **1-c. Severity is a classification too. Do not decide it from one reproduction.** Rule 1 says
 decide "does it happen" by execution; it says **nothing about how far it happens**. The procedure
@@ -150,7 +161,7 @@ operator does not lower the count — it decides which site you check first.
 **Reach for the pattern this repository already uses three times** (`_SCRATCH_SURFACES`,
 `_REDIRECT_RULE_SURFACES`, `_SURFACES` in `tools/tests/test_hooks_cli.py`) — but they are three
 DIFFERENT shapes and **they duplicate each other**, so read the one nearest your rule and treat
-copying as the starting point. The six traps, each of which cost a round (the count was wrong here — "four" over five bullets — until issue #143 added the sixth, which is this rule's own enumeration trap turned on itself):
+copying as the starting point. The ten traps, each of which cost a round (the count was wrong here — "four" over five bullets — until issue #143 added the sixth, which is this rule's own enumeration trap turned on itself; issue #175 added the last four, all of them found by a witness census run against a coupling check written the SAME DAY, three of them demonstrated by planting the defect the check was built to refuse):
 
 - **Anchor on text that PRECEDES the rule and is byte-identical in the wording you are refusing.**
   Anchoring on your own corrected sentence pins that the correction survived, not that the rule is
@@ -192,6 +203,26 @@ copying as the starting point. The six traps, each of which cost a round (the co
   surface list**: deleting a surface that happens to carry no exempt line is invisible, which was
   3 of 5 there, so derive the surfaces from the code that decides them
   (`leaf_contract_doc_refs`) and assert the coverage
+
+- **Read the STATEMENT, not the line — prose WRAPS.** A reader that tests one line at a time
+  misses a rule written across two, and hard-wrapped Markdown and prompt templates are what these
+  surfaces are made of: issue #175's census wrote the refused fact over two lines and the check
+  passed it. Span a bounded window of CONTINUATION lines — not across a bullet, heading or fence
+  boundary, or two adjacent items joined by chance become a statement nobody wrote — report the
+  innermost match so a one-line statement keeps a one-line key, and witness BOTH directions
+- **Key the allowlist by SURFACE and content, not content alone.** A digest-only key makes
+  copying an allowlisted sentence VERBATIM into another document free — which is precisely the
+  operation that produced the copies you are coupling against, so the check's whole purchase is
+  void for it (planted and green on issue #175). It also blinds the set comparison in the other
+  direction: with one line in two files, deleting it from one raises nothing
+- **The set comparison's DISAPPEARANCE half needs its own witness.** "Compared as a set" is a
+  claim about two directions, and only one of them is exercised by every run — replacing the
+  stale computation with `[]` stays green forever. Drive it with an entry that matches nothing
+- **Deriving the surfaces is not enough if the derivation SWALLOWS a miss.** A `.is_file()` guard
+  over a derived path turns a renamed or moved file into a SMALLER scan, silently — the census
+  renamed a `SKILL` and planted a false statement in the file the rename orphaned, and the check
+  passed. A surface the code NAMES but the tree does not carry is a failure of its own row, and
+  each group's expected count comes from the same source the group does
 
 **Before adding a check, ask whether the sites should exist.** The cheaper fix is this
 repository's ordinary practice — one canonical statement, everyone else cites it (`AGENTS.md`
@@ -364,6 +395,19 @@ recipes are in `references/input-surfaces.md`:
   **Nothing in this repository's review loop finds this except rendering the prompt** — the
   mutation sweep mutates code, the census enumerates code, a blank-slate reviewer reads code, and
   all three were green on it; see `atmofab-review-loop`'s "what does a LEAF see" clause.
+  **The MIRROR is the same surface and reads as an unrelated task: changing what a leaf is TOLD
+  without changing what it is GIVEN.** Issue #175 corrected the agentic compile producer's
+  `SKILL` to say the direct dependency set is read from `<ir_ref>/dependency_graph.json` — and
+  left `build_launch_request`'s must-read set as it stood, so the one leaf that reads exactly its
+  required set had no source anywhere in it for the fact its own canonical procedure named, and
+  would have failed the phase on every attempt. It stayed invisible for a whole round because
+  the PURE path inlines that same file as context: the contract was true, the delivery was not,
+  and both paths' tests were green. **Rule: when you change what a contract TELLS a leaf to read,
+  count how that thing reaches EACH transport that receives the contract — the must-read set, the
+  inlined context, the template's own words — and name the one for each.** The tell is a corrected
+  sentence that names a file, in a commit with no diff to the code that assembles what the leaf is
+  handed. Same question as the paragraph above, asked from the other end: there the transport
+  moved and the contract did not, here the contract moved and the transport did not.
 
 ### 2. Confirm the path production actually takes
 

--- a/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
+++ b/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
@@ -407,3 +407,38 @@ its own to become a registry refusal. And the prompt sentence introducing the ne
 the inlined document "is" the gate's rule set, which it was not: a rule that overclaims
 completeness sends the leaf away from the rest. **When you deliver a rule set to a leaf, state
 what it does NOT cover in the same sentence.**
+
+### The mirror: the contract moved and the transport did not (issue #175)
+
+The episode above is a transport change that cut a document. The mirror is a document change that
+outran the transport, and it looks nothing like a delivery problem while you are making it.
+
+Issue #175 moved a node's `direct_deps` out of the `deps.yaml` declaration and into the
+conductor-authored `<ir_ref>/dependency_graph.json`. Five review rounds swept the sentence stating
+that fact through the two compile prompt templates, the phase document, both problem
+`controlled_spec.md`, the glossary — and, in round 4, `skills/workflow-compile-generate/SKILL.md`,
+the AGENTIC producer's canonical procedure, which was corrected to say "read it THERE, not from
+`deps.yaml`".
+
+Round 5 measured what that leaf is actually handed. `build_launch_request`'s
+`skill_must_read_refs` for `(compile, generate)` was the `SKILL`, `docs/AGENT_CONTRACT.md`, the
+phase document and the spec's three files. **The sidecar was in none of them.** A leaf reading
+exactly its required set had no source for the direct dependency set OR for the per-case
+`profile_selection` the new gate requires — on the two nodes whose `deps.yaml#components` the same
+change had emptied to `[]` — and would have failed the phase on every attempt until its retries
+were spent.
+
+Why a whole round passed with it green:
+
+- The PURE path inlines the same file as `dependency_graph_document`, so the majority transport
+  was correct and every test that renders a prompt renders that one.
+- Nothing compares a `SKILL`'s instructions against the launch request's must-read set. The
+  contract was true; the delivery was not; there is no assertion whose subject is the pair.
+- The correction that created the gap was itself a FIX, applied in a round, to a real finding.
+  Nothing about it looked like a transport change.
+
+**The enumeration, and it is the same one as above run in the other direction:** for each
+document you correct, list the leaves that receive it, and for each leaf say by which of the three
+routes the thing the sentence names arrives — the must-read set, the host-inlined context, or the
+template's own words. A blank in that table is the defect. On a repository where one contract is
+read by two transports, expect exactly one of them to be wrong.

--- a/.claude/skills/atmofab-enforcement-change/references/judgment-episodes.md
+++ b/.claude/skills/atmofab-enforcement-change/references/judgment-episodes.md
@@ -158,6 +158,28 @@ is the starting point and not the goal. The four traps, each of which cost a rou
   repair. This is the trap that is easiest to reintroduce, because pinning the spelling is
   three lines and pinning the members is fifteen
 
+**Issue #175 added four more traps, and how they were found is the point.** The rule fired for
+real: one fact — where a node's `direct_deps` comes from — was stated on ELEVEN lines across
+SEVEN files (of eight the scan covers; one carries none), six of the seven read by a compile
+leaf, and FIVE consecutive review rounds each found a
+different copy still stating the fact the change had reversed. Four of those copies were text a
+leaf acts on, each costing that leaf a `Compile fail` on every attempt. So a coupling check was
+written. **A witness census run against it the same day found four defects in it**, three of them
+by PLANTING the very defect the check exists to refuse and watching it pass:
+
+- a statement written across TWO LINES, which is what hard-wrapped Markdown and the prompt
+  templates are made of, and the reader was line-local;
+- an allowlisted line copied VERBATIM into a second surface, free because the key was the
+  digest alone — and the copy is exactly the operation that produced the eleven sites;
+- a false statement planted in a `SKILL` after renaming it, because the surface derivation
+  guarded with `.is_file()` and silently scanned one file fewer;
+- and the set comparison's STALE half, replaced with `[]` and still green, because only the
+  unread direction is exercised by an ordinary run.
+
+The lesson under the four is the one this whole section keeps restating: **the check you write to
+stop a class of defect is written by the same hand that produced the class**, so it needs the same
+treatment — plant the defect, not just the mutant. Every fix above is witnessed by planting.
+
 **Before adding a check, ask whether the sites should exist.** The cheaper fix is this
 repository's ordinary practice — one canonical statement, everyone else cites it (`AGENTS.md`
 §Dedicated rule documents) — and it cannot rot. Coupling is for the sites that must repeat the

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -960,6 +960,14 @@ could have: the sweep mutates what exists, the census enumerates what exists, an
 reviewer reads HEAD. **Everything else compares HEAD against itself.** The disclosure round is the
 one place a reviewer is pointed at the previous revision, so it is the only place a deleted
 guarantee is visible.
+**Read "deleted" widely: a guarantee is lost by RELOCATION as often as by deletion, and that
+form has no diff to point at.** On issue #175 a fact moved out of the structure an existing
+comparison reads — the adopted `profile` left the dependency sidecar's `all_nodes` for a key of
+its own, while the R6-lite freshness signature reads `all_nodes` — so the check still ran, still
+passed, and stopped seeing a whole class of change. Nothing was removed; a key was ADDED. Asking
+the axis for "a check that was narrowed away" would have missed it, so ask for **a check that
+still runs and now covers less**, and give the reviewer the old revision to run the old defect
+against: red-then-GREEN is the finding whether the cause was a narrowing, a deletion, or a move.
 
 **And "what does a LEAF see" means RENDER THE PROMPT, once per leaf that receives it — WHEN the
 branch changed text a leaf is handed.** That condition is the whole scope: a branch that touches

--- a/tools/tests/test_orchestration_runtime.py
+++ b/tools/tests/test_orchestration_runtime.py
@@ -41002,9 +41002,9 @@ class DirectDepsSourceStatementTests(unittest.TestCase):
     declaration and is now the host-derived set in `<ir_ref>/dependency_graph.json`
     (`all_nodes` minus self minus `transitive_deps`, which INCLUDES the runner harness), because
     a `profile` entry in `deps.yaml` is not a node and the `component` it selects are. The rule
-    is stated in eleven places across eight files, six of which a compile leaf receives
-    verbatim, and FIVE consecutive review rounds each found a different copy still stating the
-    old fact — four of them in text a leaf acts on, each costing that leaf a `Compile fail` on
+    is stated in eleven places across seven files — of the eight surfaces this class scans; the
+    verify `SKILL` carries none — six of the seven read by a compile leaf, and FIVE consecutive
+    review rounds each found a different copy still stating the old fact — four of them in text a leaf acts on, each costing that leaf a `Compile fail` on
     every attempt.
 
     That count is what `atmofab-enforcement-change` rule 3-a calls the point where sweeping has


### PR DESCRIPTION
Three shapes issue #175's review loop produced that neither skill carried, plus one correction to a count that PR #199 shipped. Rules in the `SKILL.md`s, episodes in `references/`, per the enforcement-change skill's own split.

## `atmofab-enforcement-change`

**Rule 1-b gains "MOVING a fact is deleting a defense you never classified."** Every other bullet under 1-b is about a deletion you decide to make; this one reaches no classification, because nothing prompts you to make one — the check still runs, still passes, and covers less. Issue #175 moved the adopted `profile` out of the dependency sidecar's `all_nodes` into a key of its own, while `_closure_signature` (the R6-lite freshness comparison) reads `all_nodes`: a profile version bump then left every adopter's signature byte-identical at the new HEAD and CHANGED it on `origin/main`. **The tell is a diff that ADDS a key rather than changing a value** — nothing looks removed.

**Surface 12 gains its mirror**: changing what a leaf is TOLD without changing what it is GIVEN. Round 4 of that loop corrected the agentic compile producer's `SKILL` to say the direct dependency set comes from `<ir_ref>/dependency_graph.json`; round 5 measured that `build_launch_request`'s must-read set did not carry it, so a leaf reading exactly its required set had no source for the fact its own canonical procedure named. It stayed green for a whole round because the PURE path inlines the same file — the contract was true, the delivery was not, and nothing in the tree asserts about the pair.

**Rule 3-a's trap list goes 6 → 10.** How the four were found is the point: a witness census run against the coupling check *the same day it was written* found four defects in it, three by planting the very defect the check exists to refuse — a statement wrapped over two lines (the reader was line-local); an allowlisted line copied verbatim into a second surface (the key was content-only, so the copy was free — and copying is exactly the operation that produces the sites you are coupling against); a false statement in a renamed file the derivation silently stopped scanning; and the set comparison's disappearance half, replaced with `[]` and still green.

## `atmofab-review-loop`

The disclosure axis's "what CHECK went with what was deleted" clause now says to read *deleted* widely. Asking for "a check that was narrowed away" would have missed issue #175's; asking for **a check that still runs and now covers less** finds it. The red-then-GREEN procedure is unchanged.

## A correction

`DirectDepsSourceStatementTests`' docstring said the rule is stated "in eleven places across eight files". Re-measured on merged `main` by driving `_statement_keys`: **eleven statements across seven files** — eight is the number of SURFACES the class scans, one of which carries none. Six of the seven are leaf-read, which was right. The commit messages of `9577d19` and `63aaf2c` carry the same figure and cannot be edited; PR #199's body is corrected in place and says so.

That miss is the flip side of rule 3 — prose written in the same commit as the thing it describes is unverified until you run it — restated by this very branch's edits and broken by it anyway. Recorded rather than quietly fixed.

Suite: 6251 passed, 3360 subtests passed at `493ac6c` (`python3 -m pytest tools/tests -q -p no:randomly`, primary checkout `/home/seiya/atmofab`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm2df8R5uJjj3UwDXUerTp
