### PR TITLE
atmofab-review-loop: add the sign for prose that explains a tool's mechanism

### DIFF
--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -1103,20 +1103,22 @@ that tells you how it closed.
   measurement was stated twice. **This is not the "prose that enumerates entities" row**: that one
   says turn prose into a check, this one says the check is already there
 - **A sentence of yours explains WHY A TOOL BEHAVES as it does** → drive it or delete it; do not
-  correct it. The subject is a third party's behaviour — pytest's collection, a CLI's flag, git's
-  path resolution — so there is no assertion beside it (the row above) and nothing to turn it into
-  a check (the row below): the sentence is load-bearing and unwitnessed by construction.
-  **Criterion, one command: name the command whose output IS the sentence.** If you cannot, you
-  have written a guess with the grammar of a fact, and the fix is to state what you OBSERVED and
-  drop the "because". Issue #183 / PR #202 reached the five-round cap on one class, and it was
-  this one: five mechanism claims measured false, each written while correcting the previous, all
-  in a branch whose subject was retiring tests that pin prose. **Correcting them individually does
-  not close it** — round 4 switched to deleting the explanations wholesale and round 5 still
-  returned six. **And no instrument in this loop fires on it**: on a deletion / prose diff the
-  round-0 sweep has no revertible hunk, the census enumerates code and the mutation sweep mutates
-  code, so every one of those findings came from a reviewer reading a sentence and running it.
-  Budget for that: put "run every command and mechanism claim the prose asserts" in the launch
-  prompt from round 1, because nothing else will look
+  correct it. Its subject is a third party's behaviour — pytest's collection, a CLI's flag, git's
+  path resolution — so there is no assertion beside the sentence and nothing to turn it into a
+  check; you have to go and make the check. **Criterion: name the run whose output the sentence is
+  a reading of, and say which reading it is.** One command is the common case; a DIFFERENTIAL (the
+  same command with the property and without it) and a cited upstream default plus one run both
+  qualify. What does not is a mechanism inferred from an outcome — you measured that the count did
+  not change and wrote down WHY it did not. **The fix is not to delete the "because"**: a
+  justification is what stops the next person removing the line, and this repository's own
+  `pytest.ini` and `tests.yml` comments are correct examples. State the observation, name its run,
+  and mark a generalization as one. **Nearest neighbour: "The fix was to a RECORD, so you verified
+  it by reading" above** — same criterion, different subject, and it is the row to read first.
+  **These are second-category text** by the taxonomy under "Stopping conditions", so correct one in
+  the commit that notices it and do not spend a round on it: put "run every command and every
+  mechanism claim the prose asserts, and report the ones whose output is not what the sentence
+  says" in the round-1 launch prompt instead. Issue #183 / PR #202 paid five rounds for not having
+  done that; `references/signs-episodes.md` has what it cost and what did not close it
 - **A term you coined for a tool has appeared in a document as if the system used it** → check it
   against the vocabulary the repository already defines. On PR #100 a reporting script labelled any
   body it could not parse "body is not an event stream", and that phrase was then written into

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -1102,6 +1102,21 @@ that tells you how it closed.
   the assertion contradicted, and each round corrected the prose rather than asking why a
   measurement was stated twice. **This is not the "prose that enumerates entities" row**: that one
   says turn prose into a check, this one says the check is already there
+- **A sentence of yours explains WHY A TOOL BEHAVES as it does** → drive it or delete it; do not
+  correct it. The subject is a third party's behaviour — pytest's collection, a CLI's flag, git's
+  path resolution — so there is no assertion beside it (the row above) and nothing to turn it into
+  a check (the row below): the sentence is load-bearing and unwitnessed by construction.
+  **Criterion, one command: name the command whose output IS the sentence.** If you cannot, you
+  have written a guess with the grammar of a fact, and the fix is to state what you OBSERVED and
+  drop the "because". Issue #183 / PR #202 reached the five-round cap on one class, and it was
+  this one: five mechanism claims measured false, each written while correcting the previous, all
+  in a branch whose subject was retiring tests that pin prose. **Correcting them individually does
+  not close it** — round 4 switched to deleting the explanations wholesale and round 5 still
+  returned six. **And no instrument in this loop fires on it**: on a deletion / prose diff the
+  round-0 sweep has no revertible hunk, the census enumerates code and the mutation sweep mutates
+  code, so every one of those findings came from a reviewer reading a sentence and running it.
+  Budget for that: put "run every command and mechanism claim the prose asserts" in the launch
+  prompt from round 1, because nothing else will look
 - **A term you coined for a tool has appeared in a document as if the system used it** → check it
   against the vocabulary the repository already defines. On PR #100 a reporting script labelled any
   body it could not parse "body is not an event stream", and that phrase was then written into

--- a/.claude/skills/atmofab-review-loop/references/class-descent-log.md
+++ b/.claude/skills/atmofab-review-loop/references/class-descent-log.md
@@ -516,3 +516,41 @@ repository exists to do, and no finding-defined condition can see that.
 finding already on the table at round 5 is fixed before the branch moves, and the fix commit
 answering it is not a sixth round. A budget that let a known `leaf shortcut` ship would be a
 fail-open dressed as a process rule.
+
+## PR #202 / issue #183 — five rounds, no descent, and the class was PROSE
+
+Real findings per round: **5, 4, 3, 6, 6**. The loop ran to the cap and stopped there without
+meeting a stopping condition; the disclosure went into the pull request body, which is the
+convention for a remainder.
+
+**Read this one for the shape, because the shape is the surprise.** The change was a deletion —
+three meta-tests retired, two moved — so almost no code moved, and every instrument this loop
+carries answers about code. What did not descend was a single prose class: a sentence explaining
+WHY a tool behaves as it does, written from a measured OUTCOME rather than from a run of the
+mechanism. `signs-episodes.md` §"A sentence of yours explains WHY A TOOL BEHAVES as it does" holds
+the five instances, the sixth that got into the record of the class itself, and the criterion.
+
+Two things this history is evidence for, and one it is not.
+
+- **It is evidence that a shape change is not a substitute for the audit.** Round 4 stopped
+  correcting the sentences and deleted the explanations wholesale, which was the right move by the
+  "rewritten the same string three times" row. Round 5 still returned six, four of them inside
+  round 4's own fixes and two inside the two rewrites themselves.
+- **It is evidence for where the budget should have gone.** All ~24 findings came from a reviewer
+  reading a sentence and running the command it implied — a round-1 launch-prompt line, not a
+  round of its own. `SKILL.md`'s own taxonomy puts this text in the second category, which never
+  advances or resets a stopping condition, so a loop that reaches the cap on it has been spending
+  rounds on something the file already says not to spend rounds on. **The cap was reached
+  legitimately and the rounds were not the right instrument.**
+- **It is NOT evidence that five rounds were needed to find one functional defect.** There was
+  exactly one — the move narrowed a citation check into refusing correct pointers — and the rule
+  that names its shape is the sibling skill's rule 1-b (list the readers of the OLD structure
+  before moving a fact between structures), which costs one enumeration and no round at all. The
+  branch applied it three times and missed the fourth reader.
+
+**What ended it**: the cap, not a condition. Class descent was not met; the "blank-slate reviewer
+returns zero functional defects" proxy was not met either, since round 5's blank-slate axis is
+where that defect came from. No Codex launch was spent — a prose/doc-centred diff is one of the
+cases `SKILL.md` names for a blank-slate subagent instead — so this loop is also a data point that
+the default of round 0 plus three is set by where the Codex launch lands, and a loop that does not
+spend it has no reason to reach five.

--- a/.claude/skills/atmofab-review-loop/references/signs-episodes.md
+++ b/.claude/skills/atmofab-review-loop/references/signs-episodes.md
@@ -413,3 +413,68 @@ clip it was supposed to exercise is 110 — the fixture had never been on the fa
 threshold it was measuring. The fix reserves the marker in the budget; the test asserts, in its
 own body, that its probe is longer than any clip.
 
+
+## "A sentence of yours explains WHY A TOOL BEHAVES as it does" (issue #183, PR #202)
+
+The branch retired three meta-tests that pinned documentation and process preferences, and moved
+two dev instruments' tests beside their scripts. It reached the five-round cap without converging.
+Real findings per round: **5, 4, 3, 6, 6** — no class descent — and all but one were the same
+thing: a sentence of mine asserting WHY a tool does what it does, written to explain a change I had
+measured only by its outcome.
+
+The five that were measured false, in the order they were written and caught:
+
+1. `README.md`: `pytest tools/tests` misses the relocated files "because `.claude/` is under
+   pytest's default `norecursedirs`". Removing `.*` from the list leaves that form at 6105 and the
+   bare form at 6105; only `pytest .` moves (6105 -> 6175). The property was real, the mechanism
+   named was not the one holding it, and the same clause went into a commit message.
+2. `.github/workflows/tests.yml`: dropping the `sysctl` step "turns the sandbox tests into declared
+   skips and the guard still says the suite ran all of it". Earlier in the same file, the comment
+   on that very step records the measurement: ten skips **and two failures**, which the guard's
+   `if failures:` arm catches. The general property (the guard is skip-blind) was true; the illustration was not an
+   instance in either recorded configuration.
+3. `.github/workflows/tests.yml`: the retired test "used to" check a `conftest.py` edit. Its own
+   module docstring said it could not ("which is Python and cannot be bounded by reading").
+4. `README.md`: `tools/tests/conftest.py` "is directory-scoped, so it is not loaded for a path
+   outside `tools/tests/`". `pytest .` descends into the directory and loads it as a non-initial
+   conftest, and strips — which `TODO.md:81` (e) already recorded, canonically, in as many words.
+5. `README.md`: a `conftest.py` beside the relocated tests "would put the default run back into
+   `.claude/`". A probe conftest with a `pytest_report_header` loads for the explicit instrument
+   command and for nothing else; all three default forms still collect 6105. The reasoning had been
+   transplanted from a sibling commit where it was true of a glob inside a test that RUNS in the
+   default suite, to a structure where it does not hold — and it foreclosed a cheap repair.
+
+**Correcting them one at a time did not close it.** Rounds 1 through 3 each corrected the previous
+round's sentence and each introduced the next. At round 4 the shape changed — `README.md` §Tests was
+rewritten to assert no mechanism at all, and the `TODO.md` residue entry was turned from a claim
+into a re-take PROCEDURE — and round 5 still returned six, three of them inside those two rewrites.
+That is the useful half of the record: the shape change was right and it was not sufficient, so the
+budget has to assume this class is found by reading, once per round, to the end.
+
+**Why it took five rounds: no instrument in the loop can see it.** The diff was three whole-file
+deletions (no revertible hunk, so `scripts/mutation_check.py` exits 1 and answers nothing), test-file
+hunks (excluded by default) and, measured over the finished branch at `a0c1a3f` with `git diff
+e7137ea...a0c1a3f` at git's default context width, eleven prose hunks across nine files. The witness census enumerates decisions in code;
+an independent mutation sweep mutates code. Every one of roughly twenty-four findings came from a
+reviewer reading a sentence and running the command it implied. So on a deletion or prose diff the
+launch prompt has to ask for that explicitly from round 1 — "run every command and every mechanism
+claim the prose asserts, and report the ones whose output is not what the sentence says".
+
+**What the loop's existing instructions DID catch, and when.** The disclosure brief's "a check that
+still RUNS and now covers LESS" is what the branch's only functional defect answers to: the move
+took 70 test names out of the glob `test_every_test_this_change_cites_by_name_exists` builds its
+vocabulary from, so a citation of any of them was reported as pointing at nothing — a false RED
+telling the author to delete a correct pointer. Worth noting **which** round found it: not round 3,
+the disclosure round, which was asked that question directly and returned a different (real) loss;
+round 5's blank-slate axis, which had the whole stack and no history. One reading is that the
+question needs the accumulated stack to be answerable; the other is that it wants the reviewer who
+was told nothing. Either way, do not treat one disclosure round as having settled it.
+
+Two smaller records from the same branch. A review worktree created with a RELATIVE path under
+`git -C <repo> worktree add` landed inside the checkout and `git add -A` committed it as a gitlink,
+taking the suite to `2 failed` — the accident this file's ground rules already tell reviewers to
+avoid, committed by the author who wrote the instruction into their prompts. And a delegated
+mechanical-recomputation subagent returned a closing message ("no new information, the final report
+stands as delivered") for a report that had never arrived; the full checklist came back only after
+being asked for it directly. **A subagent's completion notice is not its report** — if you cannot
+quote a finding from it, you have not received one.

--- a/.claude/skills/atmofab-review-loop/references/signs-episodes.md
+++ b/.claude/skills/atmofab-review-loop/references/signs-episodes.md
@@ -417,10 +417,12 @@ own body, that its probe is longer than any clip.
 ## "A sentence of yours explains WHY A TOOL BEHAVES as it does" (issue #183, PR #202)
 
 The branch retired three meta-tests that pinned documentation and process preferences, and moved
-two dev instruments' tests beside their scripts. It reached the five-round cap without converging.
-Real findings per round: **5, 4, 3, 6, 6** — no class descent — and all but one were the same
-thing: a sentence of mine asserting WHY a tool does what it does, written to explain a change I had
-measured only by its outcome.
+two dev instruments' tests beside their scripts. It reached the five-round cap without converging;
+the stopping history is in `class-descent-log.md`. The class that did not descend was this one:
+a sentence asserting WHY a tool does what it does, written from an outcome I had measured rather
+than from a run of the mechanism. It was the majority of the findings, not all of them — a
+subject-verb slip, a pointer true of one skill and not the other, and a record that named half of
+what a retired test held are three that belong to other rows in `SKILL.md`.
 
 The five that were measured false, in the order they were written and caught:
 
@@ -431,8 +433,8 @@ The five that were measured false, in the order they were written and caught:
 2. `.github/workflows/tests.yml`: dropping the `sysctl` step "turns the sandbox tests into declared
    skips and the guard still says the suite ran all of it". Earlier in the same file, the comment
    on that very step records the measurement: ten skips **and two failures**, which the guard's
-   `if failures:` arm catches. The general property (the guard is skip-blind) was true; the illustration was not an
-   instance in either recorded configuration.
+   `if failures:` arm catches. The general property (the guard is skip-blind) was true; the
+   illustration was not an instance in either recorded configuration.
 3. `.github/workflows/tests.yml`: the retired test "used to" check a `conftest.py` edit. Its own
    module docstring said it could not ("which is Python and cannot be bounded by reading").
 4. `README.md`: `tools/tests/conftest.py` "is directory-scoped, so it is not loaded for a path
@@ -444,37 +446,59 @@ The five that were measured false, in the order they were written and caught:
    transplanted from a sibling commit where it was true of a glob inside a test that RUNS in the
    default suite, to a structure where it does not hold — and it foreclosed a cheap repair.
 
+**And a sixth, which is the reason this section is worth its length: it went into the first version
+of this very entry.** Both #202's body and the first draft here said the loop could not use its own
+round-0 sweep, "three whole-file deletions (no revertible hunk, so `scripts/mutation_check.py`
+exits 1 and answers nothing)". Driven on the range it is about, all three halves are false: a
+whole-file deletion produces an ordinary revertible hunk (the run reports ten and drops them by the
+TEST-FILE filter, which is a different mechanism); with `--paths tools mcp_servers` the run prints
+`no hunks in range` and exits **0**; and with `--paths .` it enumerates the eleven prose hunks and
+exits 1 on the survivors, which is exactly the measurement `SKILL.md` §"Before you hand it over"
+already prescribes for a documentation-only diff. The claim contradicted two rules in the same
+file, it was transcribed from the pull request rather than driven, and it shipped in a commit whose
+message asserted every claim in it had been driven. **Nothing here is safe from the class,
+including the record of the class** — which is why the criterion in `SKILL.md` asks for the run and
+not for a plausible mechanism.
+
 **Correcting them one at a time did not close it.** Rounds 1 through 3 each corrected the previous
 round's sentence and each introduced the next. At round 4 the shape changed — `README.md` §Tests was
 rewritten to assert no mechanism at all, and the `TODO.md` residue entry was turned from a claim
-into a re-take PROCEDURE — and round 5 still returned six, three of them inside those two rewrites.
-That is the useful half of the record: the shape change was right and it was not sufficient, so the
-budget has to assume this class is found by reading, once per round, to the end.
+into a re-take PROCEDURE — and round 5 still returned six: four of them inside round 4's own fixes,
+two of those inside the two rewrites themselves. That is the useful half of the record: the shape
+change was right and it was not sufficient, so the audit has to run once per round rather than be
+designed away.
 
-**Why it took five rounds: no instrument in the loop can see it.** The diff was three whole-file
-deletions (no revertible hunk, so `scripts/mutation_check.py` exits 1 and answers nothing), test-file
-hunks (excluded by default) and, measured over the finished branch at `a0c1a3f` with `git diff
-e7137ea...a0c1a3f` at git's default context width, eleven prose hunks across nine files. The witness census enumerates decisions in code;
-an independent mutation sweep mutates code. Every one of roughly twenty-four findings came from a
-reviewer reading a sentence and running the command it implied. So on a deletion or prose diff the
-launch prompt has to ask for that explicitly from round 1 — "run every command and every mechanism
-claim the prose asserts, and report the ones whose output is not what the sentence says".
+**Why it stayed uncaught: the loop's instruments answer about code, and one of them was mis-read.**
+The witness census enumerates decisions in code and a mutation sweep mutates code, so neither speaks
+to a prose claim. The round-0 sweep is NOT inapplicable — see the sixth item above — but on this
+diff it reports every prose hunk as SURVIVED, which `SKILL.md` says to read as a measurement and
+split, not as a verdict. What actually found all of these was a reviewer reading a sentence and
+running the command it implied, so on a deletion or prose diff that has to be asked for from round
+1: "run every command and every mechanism claim the prose asserts, and report the ones whose output
+is not what the sentence says".
 
-**What the loop's existing instructions DID catch, and when.** The disclosure brief's "a check that
-still RUNS and now covers LESS" is what the branch's only functional defect answers to: the move
-took 70 test names out of the glob `test_every_test_this_change_cites_by_name_exists` builds its
-vocabulary from, so a citation of any of them was reported as pointing at nothing — a false RED
-telling the author to delete a correct pointer. Worth noting **which** round found it: not round 3,
-the disclosure round, which was asked that question directly and returned a different (real) loss;
-round 5's blank-slate axis, which had the whole stack and no history. One reading is that the
-question needs the accumulated stack to be answerable; the other is that it wants the reviewer who
-was told nothing. Either way, do not treat one disclosure round as having settled it.
+**The one functional defect on the branch, and which rule names it.** The move took 70 test names
+out of the glob `test_every_test_this_change_cites_by_name_exists` builds its vocabulary from, so a
+citation of any of them was reported as pointing at nothing — a false RED telling the author to
+delete a correct pointer. The rule that names this is the sibling skill's rule 1-b, "MOVING a fact
+is deleting a defense you never classified … before moving a fact between structures, list the
+readers of the OLD structure and say for each what it sees now"; the branch listed three such
+readers across three commits and missed the fourth. **The disclosure brief in `SKILL.md` does not
+cover it**, and the tell is in the brief's own words: it asks for a check that "still runs and now
+covers less" and says **red-then-GREEN is the finding**. This defect is the other direction —
+green-then-RED, an over-refusal — so a reviewer following that brief literally discards the
+reproduction. Which rounds found the class, on this branch: round 2's fix-focused axis (the
+shadowed-method scan's docstring), round 5's blank-slate axis (this one). Round 3, the disclosure
+round, was asked the question directly and returned a different real loss. Note that rule 1-b's own
+text says a blank-slate reviewer cannot see this shape because it compares HEAD against itself;
+round 5's did, by running the old defect against both revisions. **One of the two sentences is
+wrong and this record does not settle which** — read them together before citing either.
 
 Two smaller records from the same branch. A review worktree created with a RELATIVE path under
-`git -C <repo> worktree add` landed inside the checkout and `git add -A` committed it as a gitlink,
-taking the suite to `2 failed` — the accident this file's ground rules already tell reviewers to
-avoid, committed by the author who wrote the instruction into their prompts. And a delegated
-mechanical-recomputation subagent returned a closing message ("no new information, the final report
-stands as delivered") for a report that had never arrived; the full checklist came back only after
-being asked for it directly. **A subagent's completion notice is not its report** — if you cannot
-quote a finding from it, you have not received one.
+`git -C <repo> worktree add` landed inside the checkout and `git add -A` committed it as a gitlink
+— the accident this file's ground rules already tell reviewers to avoid, committed by the author
+who wrote the instruction into their prompts. And a delegated mechanical-recomputation subagent
+returned a closing message ("no new information, the final report stands as delivered") for a
+report that had never arrived; the full checklist came back only after being asked for it directly.
+**A subagent's completion notice is not its report** — if you cannot quote a finding from it, you
+have not received one.


### PR DESCRIPTION
Follow-up to #202 (issue #183). That loop reached the five-round cap without converging, and the class it did not descend through has no row in `.claude/skills/atmofab-review-loop/`. `SKILL.md` §Finally says to tell the user rather than rewrite silently; this is the update after that report.

## The sign

**A sentence of yours explains WHY A TOOL BEHAVES as it does** → drive it or delete it; do not correct it. Criterion, one command: **name the command whose output IS the sentence.** If you cannot, state what you OBSERVED and drop the "because".

It earns its own row because its two nearest neighbours both assume a witness exists. "A comment RESTATES a measurement the assertion beside it already carries" says the check is already there; "prose that enumerates entities in the code" says turn the prose into a check. Here the subject is a third party's behaviour — pytest's collection, a CLI flag, git's path resolution — so there is no assertion beside it and nothing to turn it into.

## Why it needed adding

On #202, five mechanism claims were measured false, each written while correcting the previous one, in a branch whose subject was retiring tests that pin prose. Real findings per round were 5, 4, 3, 6, 6 — no class descent. Round 4 changed shape (delete the explanations rather than correct them again) and round 5 still returned six, three of them inside those rewrites, so the episode records that the shape change was right and not sufficient.

And **no instrument in the loop fires on this class**: on a deletion / prose diff the round-0 sweep has no revertible hunk, the census enumerates code, the mutation sweep mutates code. All ~24 findings came from a reviewer reading a sentence and running the command it implied. The row therefore ends with what to put in the launch prompt from round 1.

`references/signs-episodes.md` carries the case history, per this skill's own rule/episode split. Three smaller records land with it: that the disclosure brief's "a check that still RUNS and now covers LESS" is what the branch's only functional defect answered to — but round 3, the disclosure round asked it directly, missed it and round 5's blank-slate axis found it (recorded as an open reading, not a conclusion); the relative-path `git worktree add` that landed inside the checkout and was committed as a gitlink by `git add -A`, by the author who had written the absolute-path instruction into every reviewer prompt that round; and **a subagent's completion notice is not its report** — a delegated axis returned "no new information, the final report stands as delivered" for a report that had never arrived.

## Applying the new rule to this change

Every claim in the added text was driven at `229a2c7` rather than recalled, and two were wrong when first written and are not in what landed:

- "seventy lines above" — the real delta is 82, and a line delta is the fragile-number shape this skill already has a row for. Now "earlier in the same file".
- "seven prose hunks" — that was the count at the START of #202's branch. Measured over the finished branch with `git diff e7137ea...a0c1a3f` at git's default context width it is **eleven, across nine files**.

The `norecursedirs` four-way table and the `TODO.md:81` (e) citation were re-measured on merged `main` and hold.

Documents only; no code changes. `.claude/skills/` is dev-layer and reaches no leaf, so no doc size ceiling applies. `test_build_runtime_server`, `test_suite_environment_isolation` and `test_backend_boundary` — the tests that read these files — pass, and the full suite is 6105 passed, 3278 subtests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm2df8R5uJjj3UwDXUerTp

---

## Review round (one round, two axes) — and what it found

**The row added to stop undriven mechanism claims contained one.** Both axes landed on it independently. It said the loop could not use its own round-0 sweep ("no revertible hunk, so `scripts/mutation_check.py` exits 1 and answers nothing"). Driven on the range it is about:

```
mutation_check.py --range e7137ea..a0c1a3f --paths tools mcp_servers --test-cmd "true" --skip-baseline
  -> ignoring 10 hunk(s) in test files ... no hunks in range     EXIT 0
mutation_check.py --range e7137ea..a0c1a3f --paths .            --test-cmd "true" --skip-baseline
  -> 11 hunk(s); 4 job(s) ... 11 unexplained survivor(s)         EXIT 1
```

Three halves, three wrong: a whole-file deletion produces an ordinary revertible hunk (ten here, dropped by the TEST-FILE filter — a different mechanism), that path exits 0, and the broad run answers by enumerating the eleven prose hunks, which `SKILL.md` round 0 already prescribes reading as a measurement. It contradicted two rules in the same file, it was transcribed from #202's body rather than driven, and it shipped under a message asserting every claim had been driven. It is now the episode's **sixth item**, written up as one — the record of the class was not safe from the class. #202's merged body has been corrected too, with the correction recorded rather than the sentence quietly swapped.

The other findings, all fixed in `54ca6da`:

| | |
|---|---|
| **The criterion over-refused.** Both axes constructed correct sentences it forbids — `pytest.ini`'s own comment on why `pytest .` bypasses `testpaths`, `tests.yml`'s "`\|\| true` **so** a runner image that removed the knob does not fail the job", and my own correct replacements, which are differential measurements. | It now asks for the run the sentence is a reading of, admits a differential or a cited upstream default plus one run, and says the fix is **not** to delete the "because" — a justification is what stops the next person removing the line. |
| **The row cited the wrong neighbour.** Its real one is "The fix was to a RECORD, so you verified it by reading" — same criterion, different subject. With that, "the class has no row in this skill" was never established: what was missing is only the third-party-tool subject. | Stated, and it points there first. |
| **It contradicted the budget taxonomy 170 lines above it** — `SKILL.md` puts maintainer-only text in the second category, which "never justifies spending a budgeted round", while the row recorded a five-round loop on that text as legitimate. | The row classifies the material and sends it to the round-1 launch prompt instead of to a round. |
| **Third statement of one sentence** ("the sweep mutates … the census enumerates …", already at two sites) — this file's own "rewritten the same string three times" row. Plus episode material carried against the rule/episode split. | Dropped. |
| **Two counts wrong**: "three of them inside those two rewrites" measures as two (`git log -S` on the introducing text); "all but one were the same thing" overstates by at least three. | Now "four inside round 4's fixes, two inside the rewrites", and the off-class findings are named. |
| **The functional defect was credited to the wrong rule.** The disclosure brief says **red-then-GREEN is the finding**; this defect is green-then-RED, an over-refusal, so a reviewer following that brief discards the reproduction. The rule that names the shape is the sibling skill's rule 1-b. | Recorded — including that rule 1-b says a blank-slate reviewer cannot see this shape and round 5's did. **One of the two sentences is wrong and the record says so rather than smoothing it over.** |
| **The which-round-found-it reading omitted the earliest instance** — round 2's fix-focused axis, `95f7382`. | Added. |
| **The stopping history was in the wrong file** — `SKILL.md:33` makes `references/class-descent-log.md` canonical for per-loop stopping histories. | Moved there as its own section, with what the history is and is not evidence for; `signs-episodes.md` cross-references it. |

Every claim in `54ca6da` was driven at that commit — the two `mutation_check.py` runs with exit codes read outside a pipeline, the `git log -S` attribution of round 5's six findings, and the three off-class findings named by their commits. Full suite: 6105 passed, 3278 subtests passed.

One round only, by the user's instruction. **Not a convergence claim**: `54ca6da` is itself unreviewed, and this branch's own history is the argument for why that matters.