### PR TITLE
skills: the evidence requirement behind rule 1-b, and rebase as a stale-figure cause

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -53,6 +53,21 @@ a fail-open that way, on the strength of **one** compiler probe).
 - This repo pushes the other way too ("delete dead defenses"). **How the tug-of-war settles**:
   you may delete only when there is **an execution record of an attempt to reach it that
   failed**. "No caller exists" (dead code) counts; "the language spec makes it impossible" does not
+- **Before claiming "no record has reached it", name what ONE RUN of the mechanism LEAVES
+  BEHIND.** The bullet above says what evidence counts and says nothing about how you obtain it,
+  and that gap is what issue #176 fell through: a census over the artifacts a mechanism writes
+  returned 0, and the mechanism does not mark them, so it would have returned 0 either way. It
+  was incapable of detecting its own subject, and the deletion shipped on it —
+  `write-step-result --backfill` had in fact run 7 times and carried an orchestration to `pass`.
+  Read `origin/main` and name the trace concretely: the `self.emit("<literal>")` event name, the
+  file that gets created, the field that gets set. **If the answer is "nothing", stop and claim
+  only what is provable** — "no in-tree caller" — rather than "it was never reached". A pure
+  reader leaves nothing; so does a writer whose write sits inside `if changed:`, which sees
+  effective runs and is blind to the no-op the resume path actually took. **Write "unreachable"
+  and "ineffective" as the different claims they are.** Which artifacts are and are not evidence,
+  and the three follow-through traps (read the whole command line before classifying a hook hit;
+  resolve WHO called it; state each artifact's coverage window):
+  `references/verification.md` §"Establishing that a mechanism was never reached"
 - **The moment you write "the language spec makes this impossible" is the most dangerous one. If
   you write it, execute one case from that spec and confirm.** What breaks these claims is always
   the language's **special form** (PEP 420 namespace packages, use association, implicit

--- a/.claude/skills/atmofab-enforcement-change/references/verification.md
+++ b/.claude/skills/atmofab-enforcement-change/references/verification.md
@@ -430,6 +430,49 @@ whether `--resume` works, the matcher semantics, and what gets written into the 
   bwrap profile and swap the leaf command for `/usr/bin/env` (that is a witness, not a capture,
   and it is free)
 
+## Establishing that a mechanism was never reached
+
+The evidence half of judgment rule 1-b. Issue #176 deleted eight recovery mechanisms on
+censuses of this shape and **one of the censuses could not see its own subject**:
+`write-step-result --backfill` was deleted on "0 backfill traces across 626
+`step_result.json`", and `--backfill` writes an ORDINARY `step_result.json` with no marker,
+so that count is 0 whether or not it ever ran. It had run 7 times, written 4 of those files,
+and carried `orch_20260619T113225Z_f48fe14b` to `pass`. The deletion was reverted.
+
+**Name the trace before you count anything.** Read `origin/main` and say what one run leaves:
+the `emit()` literal, the file, the field. Where the answer is "nothing", the claim you may
+make is "no in-tree caller", not "never reached".
+
+| artifact | what it proves | trap |
+|---|---|---|
+| `workspace*/orchestrations/*/run_logs/*.jsonl` | **strongest.** One append-only line per `Conductor.emit()` firing | copy the literal from the `self.emit("…")` CALL SITE. Searching a constant's NAME finds the definition, not the firing |
+| `workspace*/orchestrations/*/hooks/native_hook_events.jsonl` | **the only trace a CLI subcommand leaves at all** — every Bash command an agent ran, with the hook's allow/block verdict | a read-only subcommand appears nowhere else. If you skip this file you cannot say anything about a subcommand's use |
+| a field or file the mechanism itself writes (`dismissed_at`, `record_repairs.jsonl`, `post_judge_meta.disposition`) | that an EFFECTIVE run happened | blind to a no-op. `repair_legacy_agent_runs` appends inside `if changed:`, and the resume path ran it to a recorded no-op that the census cannot see |
+| `run_write_baseline.json`, `launches/*.request.json`, `*.prompt.txt` | **nothing** | they carry path names and SKILL prose, so they mass-produce false positives: 2198 hits for `record_repairs` against 1 real file, 260 for `warm_resume` against 0 real firings |
+| a string match inside the artifact the mechanism writes | **nothing, if the mechanism does not mark it** | the `--backfill` false negative above |
+
+Three follow-through traps, each of which cost a correction on issue #176:
+
+- **Read the WHOLE command line before classifying a hook hit.** `--help`, an unrelated
+  `grep` on the same line, and a `--reason-detail` that quotes the string are not
+  invocations — and the converse happened too: a line that looked like a bare `grep`
+  mentioning the name was running `repair-agent-runs --help` in its second half. A
+  correction written from the matched substring alone turned a reviewer's true report into
+  a false one.
+- **Resolve WHO called it.** Match `payload_summary.session_id` against
+  `orchestration_meta.host_session_id` and against `agent_runs.jsonl`. Before `c3585f0`
+  (2026-08-26) the dev and leaf layers shared one `tools/hooks/cli.py`, so a hook-log entry
+  is not by itself evidence of a leaf. And check the field EXISTS before claiming a match:
+  two of the five orchestrations in that census record no session id at all.
+- **State each artifact's coverage window against the mechanism's landing date.** In this
+  corpus `run_logs/` exist only for orchestrations from 2026-06-23 (48 of 202 have none), so
+  a 0 there says nothing about a mechanism that was live before it.
+
+**Enumerate with `find` / `os.walk`, never `grep`.** In an agent session `grep` may be a
+shell function over `ugrep --ignore-files`, which respects `.gitignore` — and
+`workspace*/` IS the corpus. Check with `type grep`; use `command grep` if you want the
+binary.
+
 ## Sweeping the prose (whenever you change a rule)
 
 Look for sentences that **cite the rule as grounds**. They are scattered across docstrings,

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -331,6 +331,15 @@ when a rule does not obviously apply:
    - **Write every measurement as a HISTORICAL RECORD naming the commit it was taken at** ("at
      `7c6d187`: 17 hunks, 10 killed …"). A record cannot go stale; a claim about the present can,
      and will, once per round
+   - **A REBASE invalidates every figure in the rebased commits' messages, and the rule above does
+     not save you** — it says to name the commit, and a rebase makes the commit a different one
+     with the same message. It fires on a stacked branch every time the lower PR gains a commit:
+     issue #176 rebased the upper branch five times, and three bodies kept a suite count measured
+     before the lower branch grew a revert that restores 8 tests, so the branch reads as jumping
+     +8 at a commit whose diff adds no test. **Re-measure after the FINAL rebase, or write the
+     figure as measured at a named pre-rebase SHA.** The same rebase orphans any SHA a body
+     CITES — three there, two of them different SHAs for one commit — and those resolve from
+     loose objects on the author's machine while resolving nowhere else. `references/measurement-records.md`
    - **State the PROPERTY the count stands for, next to the count** ("every behavioural hunk is
      pinned") — that is what the reader needs and what survives when the number is obsolete
    - **A count with no unit is not reproducible** — "14 hunks" came back as 19 and 16 because the

--- a/.claude/skills/atmofab-review-loop/references/measurement-records.md
+++ b/.claude/skills/atmofab-review-loop/references/measurement-records.md
@@ -192,6 +192,45 @@ your own; issue #153 above says re-measure at the commit you are about to name. 
 danger is a figure you did not produce. This one I produced myself, from a command I ran, on a log I
 opened — and running the command is not what makes the reading a measurement.
 
+## Issue #176 — five rebases, and the figures that described a commit that no longer existed
+
+`chore/176-delete-dismiss-violation` was stacked on `chore/176-delete-unreached-recovery-surface`
+and rebased onto it after every review round — five times. The lower branch kept gaining commits,
+one of them a revert that restores 8 test functions. Each rebase rewrote the upper branch's
+commits; none of them rewrote the numbers in those commits' messages.
+
+Measured with `--collect-only` at each commit, in a worktree, after the last rebase:
+
+| commit | message says | actually collects |
+|---|---|---|
+| the deletion | 6002 passed / 6002 collected | **6011** |
+| round 1 fix | 6003 passed | **6011** |
+| round 2 fix | 6003 passed | **6011** |
+| round 3 fix | 6011 passed | 6011 ✓ |
+| round 4 fix | 6011 passed | 6011 ✓ |
+
+The subtest halves were right throughout, and every figure was correct WHEN WRITTEN. What a
+reader sees is the branch jumping 6003 → 6011 at the round-3 commit, whose diff adds no test
+function and accounts for none of it.
+
+**Why the standing rule did not catch it.** "Write every measurement as a historical record
+naming the commit it was taken at" is satisfied by a body that states a figure for the commit it
+sits in — and a rebase replaces that commit with a new one carrying the same body. The record is
+not stale in the way the rule anticipates (a later change making it wrong); the commit it
+describes stopped existing.
+
+**The same rebase orphaned three cited SHAs.** Bodies on that branch cite `36de87d`, `9bdc0f4`
+and `b7130e1`, all pre-rebase versions of two commits — and two of them are different SHAs for
+the SAME commit, used in one body. They resolve today only from the author's loose objects; on a
+fresh clone, or after `gc`, three commit bodies cite commits that do not exist. `c3585f0` and
+`8892217`, which are real history, resolve normally. The tell that they were not real history was
+`git merge-base --is-ancestor <sha> HEAD` returning no.
+
+A second, smaller thing that rebase did on the same branch: `git rebase --continue` after a
+manually resolved conflict **dropped a commit's SUBJECT line**, leaving its first paragraph as
+the subject. It was unpushed, so it was fixed by rewording that commit and replaying the four
+above it — and the fix was recorded in the later commit rather than left to look like history.
+
 ## The published instrument went stale beside the number it produced (issue #181, PR #191)
 
 The pull request published its verification script — the thing that produced `0 non-verbatim units`


### PR DESCRIPTION
Two rules issue #176 paid for, applied to the skills. Documentation only.

## A — `atmofab-enforcement-change` rule 1-b gains its evidence half

Rule 1-b said which evidence licenses deleting a defense — *"an execution record of an attempt to reach it that failed; 'no caller exists' counts"* — and said nothing about how to obtain it. #176 fell through that gap.

`write-step-result --backfill` was deleted on "0 backfill traces across 626 `step_result.json`". `--backfill` writes an ordinary `step_result.json` **with no marker**, so that census returns 0 whether or not it ever ran. It had run 7 times, written 4 of those files, and carried an orchestration to `pass`. Reverted in #204.

The new bullet requires **naming what one run leaves behind** — the `emit()` literal, the file, the field — before counting anything, and stopping at "no in-tree caller" where the answer is "nothing". It also splits two claims the branch conflated: **unreachable** (the shape cannot be produced) versus **ineffective** (it runs and does nothing) — the resume path really did reach `repair-agent-runs` and record a no-op, which an `if changed:`-guarded census cannot see.

`references/verification.md` §"Establishing that a mechanism was never reached" carries the table, with the rates that make the point measured rather than asserted:

| artifact | measured |
|---|---|
| `run_write_baseline.json` / `*.request.json` | 2198 hits for `record_repairs` against **1** real file; 260 for `warm_resume` against **0** real firings |
| a string match inside the artifact the mechanism writes | 0 for `--backfill` against **7** real invocations |
| `hooks/native_hook_events.jsonl` | the only trace a read-only CLI subcommand leaves at all |

Plus three follow-through traps, each of which cost a correction on #176: read the whole command line before classifying a hook hit (a line that looked like a bare `grep` was running `repair-agent-runs --help` in its second half); resolve WHO called it, and check the session field exists before claiming a match (two of five orchestrations record none); state each artifact's coverage window against the mechanism's landing date (`run_logs/` exist only from 2026-06-23 here).

## B — `atmofab-review-loop`: a rebase invalidates the figures in the rebased messages

The standing rule is "write every measurement as a historical record naming the commit it was taken at". A rebase satisfies it and breaks it at once: the body is correct for the commit it was written against, and that commit no longer exists. On a stacked branch it fires every time the lower PR gains a commit.

#176 rebased five times. Three bodies kept a count taken before the lower branch grew a revert restoring 8 tests, so the branch reads as jumping 6003 → 6011 at a commit whose diff adds no test function. The same rebases orphaned three cited SHAs — two of them different SHAs for one commit — which resolve from the author's loose objects and nowhere else.

## Verification

Documentation only: **4 hunks at `--unified=3`, all four prose, +106 lines**. Hunk mutation is not applicable to a prose diff and is declared rather than run. The mechanically checkable claims are the paths and the SHAs, and both are checked:

- every cited path resolves under `git ls-files --error-unmatch` — no test does this since #183 retired `test_skill_citations.py`
- every SHA the new text names (`c3585f0`, `8892217`, `e96d2cf`, `caa10ab`) resolves in this history, as does `orch_20260619T113225Z_f48fe14b`
- `tools/tests/` 6011 passed / 3276 subtests

Neither SKILL is in `ChildContextDocSizeTests._CEILINGS` — dev-layer skills no leaf reads — so growth is recorded instead: enforcement-change SKILL 592→607, `verification.md` 597→640, review-loop SKILL 1267→1276, `measurement-records.md` 227→266.

## Not applied

A third proposal was reported to the operator and deliberately not written: `scripts/mutation_check.py` returned **three unreproducible `killed` verdicts on a comment-only commit** (AST identical to its parent modulo docstrings; all five hunks green when hand-reverted under the script's exact `--test-cmd`). Third instance of the class the skill records from issue #153, and the sharpest — here "there is no behaviour to pin" is provable. Cause unidentified, and the skill's own rule is not to spend a round on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm2df8R5uJjj3UwDXUerTp
