### PR TITLE
skills: the three traps issue #180 sprang (absence-witness, one rule in two forms, a concurrently-contaminated probe)

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -151,7 +151,13 @@ contaminated** — a compiler writes artifacts beside its input and reads them b
 be answered by what the PREVIOUS shape left, and a cleanup line between two probes makes one
 recorded row into two environments (issue #153 recorded a `gfortran` rc=0 that holds only with a
 stale `.smod` present, beside a rc=1 taken after the `rm`; `references/verification.md`
-§"Verification steps that silently do not run" carries the reproduction); and **the flip side of rule 3 is that prose you newly write in the same commit is
+§"Verification steps that silently do not run" carries the reproduction). **The contaminant need
+not be the probe's own history: a suite running CONCURRENTLY can be swapping the file the probe
+reads** — issue #180 ran `test_backend_boundary --check-baseline` while the suite was in flight
+and read the one-entry baseline `test_write_baseline_actually_writes_the_measurement` installs
+at the REAL path for the length of one `try`, getting every scanned file reported as growth from
+zero, with `git status` clean throughout because the test restores the bytes in its `finally`. **Run the verification set with nothing
+else in flight, and say so beside the number.** And **the flip side of rule 3 is that prose you newly write in the same commit is
 unverified until you run it** (L128 got four freshly written measurements or citations wrong
 inside the fix itself). **Do not write someone else's measurement as your own** — cite the source
 explicitly, or re-measure before writing. **The place this fires that you will not expect is a
@@ -176,7 +182,7 @@ operator does not lower the count — it decides which site you check first.
 **Reach for the pattern this repository already uses three times** (`_SCRATCH_SURFACES`,
 `_REDIRECT_RULE_SURFACES`, `_SURFACES` in `tools/tests/test_hooks_cli.py`) — but they are three
 DIFFERENT shapes and **they duplicate each other**, so read the one nearest your rule and treat
-copying as the starting point. The ten traps, each of which cost a round (the count was wrong here — "four" over five bullets — until issue #143 added the sixth, which is this rule's own enumeration trap turned on itself; issue #175 added the last four, all of them found by a witness census run against a coupling check written the SAME DAY, three of them demonstrated by planting the defect the check was built to refuse):
+copying as the starting point. The eleven traps, each of which cost a round (the count has now been wrong here TWICE, both times by addition and both times caught late: "four" over five bullets until issue #143 added the sixth, which is this rule's own enumeration trap turned on itself; then "ten" over eleven, when issue #180 added the STATEMENTS-per-site bullet and did not re-count — the same trap, a third time, in the same sentence. Issue #175 added four of them, all found by a witness census run against a coupling check written the SAME DAY, three demonstrated by planting the defect the check was built to refuse. **Re-count this sentence whenever you add a bullet; nothing compares it to the list.**):
 
 - **Anchor on text that PRECEDES the rule and is byte-identical in the wording you are refusing.**
   Anchoring on your own corrected sentence pins that the correction survived, not that the rule is
@@ -201,6 +207,22 @@ copying as the starting point. The ten traps, each of which cost a round (the co
   requiring each element to OPEN its own bullet there. The count is the other half: a document
   that says "three channels" and lists two is only wrong if something compares the two, and the
   number belongs to the code
+- **Count the STATEMENTS per site, not the sites — one rule is routinely stated twice in one
+  place, in two different FORMS, and coupling either one leaves the other free.** The bullet
+  above is about the ELEMENTS of an enumeration; this is about the same rule said a second way
+  beside the first, which does not look like a second site at all. Issue #180 coupled
+  `validate_pipeline_semantics`'s `--stage` set to the validator's argparse `choices` at both of
+  its restatements — and each restatement says the set TWICE: as the alternation
+  `'stage': 'a|b|c'`, and as a prose qualifier naming which stage takes `ir_ref`
+  (`(compile stage)`). The check read the alternation only, so setting BOTH qualifiers to
+  `(plan stage)` — `plan` being the non-existent stage whose appearance in that help was the
+  finding the check was written for — left the file green. **The fix is not a wider regex: it is
+  to find the CODE that answers the second form too** (there, driving each declared stage and
+  reading which one's violation says `requires non-empty --ir-ref`) and couple it separately,
+  self-testing the derivation so a reworded answer fails the row instead of silently answering a
+  different question. **The tell**: a restatement that reads as a sentence rather than a list —
+  the qualifier, the "(defaults to …)", the "…, which is what the gate runs" — sitting inside the
+  same cell as the machine-shaped form you coupled
 - **An EXEMPTION is a rule too, and it gets broken from both sides.** When the check must let
   something through — a routing sentence that legitimately names the thing you are refusing —
   do not decide the exemption by pattern. Issue #143 tried "the line cites the phase doc", then

--- a/.claude/skills/atmofab-enforcement-change/references/judgment-episodes.md
+++ b/.claude/skills/atmofab-enforcement-change/references/judgment-episodes.md
@@ -252,3 +252,44 @@ Moved from `SKILL.md` §4 "Tests pin properties", which keeps the rule and the d
     `origin/main`'s wording and see it actually fail — "I asserted the new wording, so it is
     pinned" is inference
 
+## Rule 3-a: one rule, two forms, one cell — and the count wrong for the third time (issue #180, 2026-09-10)
+
+Issue #180 retired a gate and, in doing so, hand-edited the row of `docs/CLI_REFERENCE.md` and
+the `run-gate` help string that both restate `validate_pipeline_semantics`'s `--stage` set. A
+review round found the help teaching `plan`, a stage argparse rejects, while the document had it
+right — two restatements that had drifted apart from each other with nothing comparing them.
+Three statement sites is rule 3-a's trigger, so the fix coupled both restatements to the
+validator's argparse `choices`, read by driving the CLI with a value it must reject.
+
+**The coupling covered half the rule.** Each restatement says the set TWICE:
+
+    'stage': 'compile|post_generate|post_build|post_execute|pre_judge|full'   <- the alternation
+    'ir_ref': 'workspace/ir/...'(compile stage)                              <- the qualifier
+
+The check read the alternation. A later round set BOTH qualifiers to `(plan stage)` — the exact
+defect the class exists for, `plan` and all — and the file stayed at `6 passed`. The second
+statement was never coupled, and it does not read as a second SITE: it sits in the same cell,
+one clause along.
+
+**What closed it**: finding the code that answers the second form, rather than widening the
+regex. The validator itself says which stage takes `--ir-ref` — run each declared stage bare and
+exactly one violation reads `requires non-empty --ir-ref` — so the qualifier is compared against
+a derived value, with the derivation self-tested (exactly one stage must match, or the row fails
+naming the reworded violation as the cause). Witnessed with the round's own attack: both
+qualifiers set to `plan` redden both rows here and leave the old form green on the same tree.
+
+**Cost**: one round, on a check written to prevent exactly this, three commits earlier.
+
+**And the same round broke the rule a second way, in the sentence that counts these traps.**
+Adding the bullet made eleven; the prose still said "ten", exactly as it had said "four" over
+five bullets before issue #143. That sentence has now been wrong twice, both times by ADDITION,
+both times caught by a reviewer rather than by the author who added the bullet — which is why it
+now carries an instruction to re-count, and why the honest description of rule 3-a's own
+enumeration trap is that it has fired ON ITSELF three times. Nothing compares the number to the
+list; a check that did would be four lines, and the reason there is not one is that this file is
+prose a person reads, not a surface a leaf acts on.
+
+**The generalisable tell**: a restatement that reads as a SENTENCE rather than a list — a
+qualifier, a "(defaults to …)", a "…, which is what the gate runs" — sitting beside the
+machine-shaped form you coupled. The machine-shaped form is the one you notice; the sentence is
+the one that stays free.

--- a/.claude/skills/atmofab-enforcement-change/references/verification.md
+++ b/.claude/skills/atmofab-enforcement-change/references/verification.md
@@ -91,6 +91,41 @@ hand-typed count, rotting inside the commit that wrote it, in the file that tell
 hand-type counts. The fix then was to stop counting them here; the fix now is to stop attributing
 them to one issue.)
 
+**A PROBE THAT READS A FILE THE SUITE MUTATES MEASURES WHATEVER THE SUITE HAPPENED TO BE DOING.**
+The stateful-compiler entry below is one mechanism; this is a second, and it needs no state of
+its own — the contaminant is another process running concurrently in the same checkout.
+`python3 -m tools.tests.test_backend_boundary --check-baseline` reads
+`tools/tests/data/backend_boundary_baseline.json`, and two rows in that same module write THE
+REAL PATH and restore it in a `finally` — `test_write_baseline_actually_writes_the_measurement`
+installs `{"token_counts": {"docs/sentinel.md": {"fortran": 1}}}` there to witness that
+`_write_baseline` writes a fresh measurement rather than blessing what it found, and
+`test_write_baseline_does_not_touch_the_pinned_file` writes a sentinel to the ALLOWLIST beside
+it for the converse check. (This sentence named a third test that does not exist until the name
+was resolved against `grep -n "def test_"` — the second misattribution in one entry, which is
+why the parenthesis below is stated as a class rather than as one slip.)
+Run the check inside that window and it compares the tree against a one-entry baseline. Issue
+#180 did, and got every scanned file reported as growth from zero plus a `docs/sentinel.md:
+recorded, now absent` line — output so obviously wrong that it read as a catastrophic finding
+rather than as a bad measurement. `git status` was clean and `git diff` on the file was empty
+throughout, because the restore had already happened; the only tell was the file's mtime.
+
+(**This entry named the wrong test TWICE while being written** — first `ScannedSetTests`, which
+builds its synthetic tree and baseline in a `tempfile` directory and never touches the real
+path, then a `test_the_command_writes_only_the_baseline` that does not exist at all. Both were
+written from the shape of the output and from memory of the surrounding prose, in the file that
+says executing it is not enough. The cure is mechanical and takes one command: **resolve every
+test name you write against `grep -n "def test_"` before committing it**, the same way this
+skill already tells you to resolve a cited PATH with `git ls-files --error-unmatch`. The
+mechanism itself was re-derived by running the named row alone and watching the real file's
+mtime change while its bytes came back identical.)
+
+**The rule**: before running a verification step by hand, ask what ELSE writes the inputs it
+reads, and check nothing is in flight. Backgrounding a long suite and continuing to work is the
+setup that produces this, and it is a normal thing to do. **Two cheap habits close it**: run the
+verification set with nothing else in flight and say so beside the number, and treat an
+implausibly large finding as a suspected bad measurement before treating it as a finding — the
+same reflex as reading WHY a mutant died.
+
 **A COMPILER PROBE IS STATEFUL IN ITS WORKING DIRECTORY, and the artifact the PREVIOUS shape left
 can supply exactly what the next one is missing.** `gfortran` writes `.mod` / `.smod` beside the
 source and reads them back on the next invocation, so probing shape B where shape A just ran is not

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -251,6 +251,15 @@ when a rule does not obviously apply:
     the fixture that could produce the expected violation is removed, it does not pin its name
   - **a negative assertion is green when the detector breaks — self-test the detector**
   - **when a mutant dies, read why**: a kill from a setup error is worth exactly as much as green
+  - **a witness for an ABSENCE assertion must mutate the WRITER, not the function you are
+    calling.** Making the unit under test create file X reddens ANY `assertFalse(X.exists())`,
+    including one naming a file no code writes — so it distinguishes spellings, not coverage.
+    Issue #180 banked exactly that as the witness for a vacuity fix, and the assertion was
+    still unfalsifiable: the method it drove authors no verdict, and the real writer was one
+    frame up. **Ask whether the mutation would also have reddened an assertion about
+    something the unit under test cannot produce**; if the answer is yes it measured the
+    assertion's syntax. The parent rule above did not fire because the kill did not LOOK
+    like a setup error — it looked like the mutation working
   - **when you rewrite a test, diff what the old version observed**
   - **a test that reproduces the wiring does not observe the wiring** — and that shape lies in its
     docstring easily; grep the body for the function names the docstring claims to drive
@@ -606,6 +615,15 @@ the first in round 2, on the fix commit's own tests — four uncommitted test ed
 from context, an hour lost — with the rule sitting in this file in those words. `cp` the file to a
 scratch path first and restore from that, or mutate in a worktree; the discipline is the same at
 every point in the loop, not just at round 0.
+
+**A THIRD one, and it is the mid-loop mutation's own shape rather than a round-0 rule read late:
+the hand mutation you take to CONFIRM A FIX is the one nobody checks.** A round-0 mutant is
+scored by a script that reports survivors; a mid-loop mutant is scored by you, on a fix you
+already believe in, and a red result is what you were hoping for. Issue #180 banked one — the
+absence-assertion witness above — and it took the next round to find that the red came from the
+mutation reaching the assertion rather than the mechanism. **Before writing "witnessed" into a
+commit message, name what the mutation would ALSO have reddened.** If that list includes an
+assertion you would call vacuous, the witness is not one.
 
 **Reproduce a finding yourself before classifying it.** Real / false positive / residual /
 **real but out of scope** (below) are decided only with a record of a reproduction you ran. **The

--- a/.claude/skills/atmofab-review-loop/references/mutation-testing.md
+++ b/.claude/skills/atmofab-review-loop/references/mutation-testing.md
@@ -588,3 +588,46 @@ needs a non-iterable member. Read the clause and name what would observe it.**
 SKILL.md, whose check (a) is "name a member for which the measurement could have failed". Asked of
 these three families, (a) answers immediately — and nobody asked it, three times, because a family of
 malformed values LOOKS like a family that could fail.
+
+## A witness for an ABSENCE assertion, mutated on the wrong side (issue #180, 2026-09-10)
+
+`test_gate_syntax_check_dependency_source_finding_fails_closed_not_loops` drives
+`Conductor._gate_syntax_check` and asserts that no content-fail deliverable was authored on a
+transport `fail_closed`. It did that as `assertFalse((repo / refs.source_dir() /
+"syntax_meta.json").exists())` — a name `_gate_syntax_check` never writes. A review round found
+the vacuity, and the fix respelled it to `gate_meta.json`, the deliverable a content failure
+actually authors.
+
+**The witness recorded for that fix was invalid, and it read exactly like a good one.** The
+commit said: with `_gate_syntax_check` made to write `gate_meta.json` unconditionally, the
+rewritten row is RED where the old spelling stayed green. Both halves are true and the
+inference is not. Making the UNIT UNDER TEST create file *X* turns **any** `assertFalse(X.exists())`
+red, including one naming a file no code anywhere writes; mutating it to write `syntax_meta.json`
+instead would have reddened the OLD spelling just as readily. The mutation distinguished the two
+SPELLINGS. It said nothing about whether either spelling observes the subject.
+
+**What the subject actually was.** `_gate_syntax_check` authors no verdict at all — its only
+writes are a temp-dir canary source and, further down, the persistent `syntax_evidence/<id>.json`
+certificate, both below the raise on that path. `gate_meta.json` is written by `_gate_inproc`,
+one frame up. So the respelled assertion was as unfalsifiable as the one it replaced. Mutating
+the REAL writer — `_gate_inproc` made to write `gate_meta.json` unconditionally — reddens exactly
+two rows in `DeterministicGateTest`, neither of them this one, which is where the property was
+pinned all along.
+
+**What it cost**: a round. The next round's correctness axis found it, and the fix was to DELETE
+the assertion rather than re-point it (a third copy of a property two rows already carry), and to
+say in the comment where the property lives and what witnesses it.
+
+**The tell, and it generalises past absences.** The mutation reached the assertion through the
+FILESYSTEM rather than through the mechanism the test names. Ask, before banking a red: *would
+this mutation have reddened an assertion about something the unit under test cannot produce?* If
+yes, it measured the assertion's syntax. For an absence assertion specifically: **mutate the
+writer you claim would violate it, not the function you happen to be calling** — and if the
+function you are calling cannot write the file under any input, there is nothing to witness,
+because the assertion is vacuous whatever it names.
+
+**Cross-reference.** SKILL.md's "when a mutant dies, read why: a kill from a setup error is worth
+exactly as much as green" is this rule's parent, and it did not fire, because the kill did not
+look like a setup error — it looked like the mutation working. The trigger point is narrower than
+the parent suggests: it is not only round 0's sweep but every hand mutation taken mid-loop to
+confirm a fix.


### PR DESCRIPTION
`atmofab-enforcement-change` §7's judgment for issue #180 (#207), carried out at the operator's
instruction. Documentation only — no code, no test, nothing in `tools/`.

All three are **"the rule was there and its trigger point was elsewhere"**, which §7 asks to be
distinguished from "the rule was missing". Each is a narrowing of an existing rule, with the
EPISODE in the reference file and the RULE in the SKILL — the split that keeps the SKILLs
loadable.

| # | existing rule that did not fire | why it did not | where the narrowing went |
|---|---|---|---|
| 1 | "when a mutant dies, read why: a kill from a setup error is worth exactly as much as green" | the kill did not look like a setup error — it looked like the mutation working | `atmofab-review-loop/SKILL.md` ×2 (the countermeasure list, and the mid-round paragraph) |
| 2 | rule 3-a, "when the rule is an ENUMERATION, couple element by element" | the second statement was not another element, or another site — it was the same rule said a second way in the same cell | `atmofab-enforcement-change/SKILL.md` rule 3-a |
| 3 | rule 3, "executing it is not enough if the probe was contaminated" | the existing instance is a probe contaminated by its OWN history; this one by a concurrent suite | `atmofab-enforcement-change/SKILL.md` rule 3 |

## What each cost on #207

1. **A round.** An `assertFalse(X.exists())` was "witnessed" by making the unit under test create
   X — which reddens any such assertion, including one naming a file no code writes. It measured
   the filename spelling. The assertion stayed unfalsifiable (the method drives no writer; the
   real one is a frame up), and the next round found it.
2. **A round, on a check written three commits earlier to prevent exactly that defect.** The
   `--stage` set is stated twice per restatement — an alternation and a prose qualifier — and the
   coupling read the alternation only, so the non-existent `plan` stage could be reinstated in
   both qualifiers with the file green.
3. **Nearly a false catastrophic finding.** `--check-baseline` run mid-suite read the one-entry
   baseline a row installs at the real path inside a `try`, and reported every scanned file as
   growth from zero. `git status` was clean throughout, because the `finally` had already run.

## Two things worth reading in the diff beyond the rules

**Rule 3-a's own enumeration trap fired on it a third time.** Adding the bullet made the list
eleven while its prose said "ten" — the same shape as the "four over five bullets" it already
records. Corrected, both recurrences kept, and the sentence now carries an instruction to
re-count, since nothing compares the number to the list.

**The write-up sprang rule 3 twice, in the entry for item 3**, and says so rather than being
quietly corrected: it first blamed `ScannedSetTests` (which never touches the real path) and then
invented a test name outright, both written from the shape of the output rather than from the
code. The mechanical cure is now in the entry — resolve every test name against
`grep -n "def test_"` before committing, as the skill already says to do for a cited path with
`git ls-files --error-unmatch`. All five edited files were swept that way; the two names that
still do not resolve in `mutation-testing.md` predate this change, and the one in
`verification.md` is the invented name, quoted as the slip.

## Verification

- The mechanism behind item 3 re-derived by execution: running that one row alone changes the
  real baseline's mtime while its bytes come back identical, and the sentinel it installs
  (`docs/sentinel.md`) is the string that appeared in the bad measurement.
- `python3 -m pytest .claude/skills/atmofab-review-loop/scripts/tests -q -p no:randomly` — 52
  passed, 9 subtests passed.
- No test in `tools/tests` reads these files (checked), so the suite says nothing about this
  change either way; that is the whole content of its green.
- Every cited skill-relative path resolves under `git ls-files --error-unmatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm2df8R5uJjj3UwDXUerTp