### PR TITLE
skills: a gate that reads for a spelling does not see a pointer, and an absence is a claim

### DIFF
--- a/.claude/skills/atmofab-enforcement-change/SKILL.md
+++ b/.claude/skills/atmofab-enforcement-change/SKILL.md
@@ -307,7 +307,7 @@ When a rule derives its safety from an enumeration, **write a test that kills ea
 enumeration by mutation** (round 0 in `atmofab-review-loop`). A missing element shows up in no
 other test.
 
-The eight surfaces that are none of exec / env / argv / FS / evidence paths and none of the
+The nine surfaces that are none of exec / env / argv / FS / evidence paths and none of the
 spelling variation. Each is one question; the episodes, the version tables and the measurement
 recipes are in `references/input-surfaces.md`:
 
@@ -445,6 +445,29 @@ recipes are in `references/input-surfaces.md`:
   sentence that names a file, in a commit with no diff to the code that assembles what the leaf is
   handed. Same question as the paragraph above, asked from the other end: there the transport
   moved and the contract did not, here the contract moved and the transport did not.
+- **Surface 13 — a gate that refuses a SPELLING does not refuse a POINTER to where that spelling
+  lives.** Every guard in this repository that protects a leaf-read surface decides by reading the
+  text for a token: the severity allowlist refuses a severity VALUE, the restatement scans refuse a
+  known sentence. A `file:line` citation contains none of those tokens and passes, while telling
+  the reader exactly where to find them — so the guarded fact reaches the leaf anyway, by
+  reference. Issue #168: a `docs/RUNBOOK.md` bullet was rewritten to name the constants behind a
+  cost claim, with four `tools/*.py:<line>` citations and the sentence "Read the four constants for
+  the run you are looking at". `docs/RUNBOOK.md` sits in the CLOSED judgment-rule list of both
+  verify `SKILL`s, whose closing sentence forbids reading `tools/` for judgment rules, and the
+  cited module holds `classify_verify_severity` — which says that in `dev` a `major` fail-closes
+  the run while a `minor` buys a warm same-phase repair turn. A leaf that follows the instruction
+  learns which grade is the cheap exit: the hand-assignment the allowlist exists to prevent,
+  delivered by a pointer the allowlist cannot see. **Rule: when you add a REFERENCE to a surface
+  some check guards, ask what the TARGET contains that the check forbids HERE — the check cannot
+  ask it for you. Prefer naming the fact, or the canonical document that owns it, over naming the
+  file and the line.** **The tell is a diff that adds no token any guard looks for**, which is why
+  no gate, no mutation sweep and no census sees it; what found it was a CORPUS DELTA on the
+  citation FORM — `os.walk` for `tools/*.py:<line>` over the leaf-read documents, zero before the
+  branch and four after, and the guarded document was the only one in the tree carrying any. Take
+  that count on every surface a check guards, not just the file you edited. Distinct from surface 5,
+  where caller-controlled data pollutes a classification the host computes: nothing here is
+  caller-controlled, and the guard is simply answering "does this text CONTAIN the thing" when the
+  question is "does this text DELIVER the thing".
 
 ### 2. Confirm the path production actually takes
 

--- a/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
+++ b/.claude/skills/atmofab-enforcement-change/references/input-surfaces.md
@@ -444,3 +444,71 @@ document you correct, list the leaves that receive it, and for each leaf say by 
 routes the thing the sentence names arrives — the must-read set, the host-inlined context, or the
 template's own words. A blank in that table is the defect. On a repository where one contract is
 read by two transports, expect exactly one of them to be wrong.
+
+## Surface 13 — the guard reads for a spelling; a pointer walks past it (issue #168)
+
+**What happened.** A `docs/RUNBOOK.md` bullet quoted a wrong number for what a blind `--resume`
+costs. It was corrected twice and was still wrong the third time, so the summary was deleted and
+replaced by the mechanism: the three independent budgets, each named with its constant and its
+`file:line`, closing with "Read the four constants for the run you are looking at."
+
+That document is in the CLOSED judgment-rule list of `skills/workflow-compile-verify/SKILL.md:25`
+and `skills/workflow-generate-verify/SKILL.md:18`. Both lists end: "The implementation under
+`tools/` ... must not be read to extract requirements or judgment rules." The cited module holds
+`classify_verify_severity`, which states that in `dev` a `major` or `critical` fail-closes the run
+while a `minor` buys a warm same-phase repair turn — so a verify leaf that follows the instruction
+learns that grading its finding `minor` is the cheap route to reporting its `substep` done.
+
+`tools/tests/test_pure_leaf_wiring.py`'s `_SEVERITY_ROUTING_ALLOWLIST` exists to keep exactly that
+off exactly these surfaces. It stayed green throughout: it refuses a severity VALUE, and the
+rewrite added none. The correction to the previous round's defect introduced a worse one, on the
+surface the previous round had been about.
+
+**Why nothing else caught it either.** The mutation sweep mutates what exists; the witness census
+enumerates what exists; a blank-slate reviewer reads HEAD. All three compare the branch against
+itself, and against itself the bullet is accurate prose citing real lines. It took a corpus DELTA
+on the citation form to see it:
+
+```
+# on each revision, over the documents a SKILL names or a leaf force-reads
+python3 - <<'PY'
+import os, re
+PAT = re.compile(r"tools/[a-z_]+\.py:[0-9-]+")
+for root, dirs, files in os.walk("."):
+    dirs[:] = [d for d in dirs if d not in (".git", "workspace")]
+    for f in files:
+        if not f.endswith(".md"):
+            continue
+        p = os.path.join(root, f)
+        n = len(PAT.findall(open(p, encoding="utf-8", errors="replace").read()))
+        if n:
+            print(n, p)
+PY
+```
+
+Measured: `docs/RUNBOOK.md` held 0 on `origin/main` and 4 on the branch, and it was the ONLY
+leaf-read document in the tree holding any. Re-taken after the repair, at the merge commit: two
+documents hold the form, `docs/design/deterministic_followups.md` (5) and `TODO.md` (3), and no
+`SKILL` cites either — both are dev records no leaf reaches. (An earlier version of this paragraph
+named only the first, copied from the reviewer's report rather than measured; the rule against
+writing someone else's measurement as your own applies to the write-up of the episode too.) A
+count that comes out 0 on one side and non-zero on the other, on a surface a check guards, is the
+whole finding.
+
+**Use `os.walk`, not `grep`.** In an agent session on this machine `grep` is a shell function
+execing `ugrep --ignore-files`, so it honours `.gitignore` and a corpus count taken with it is not
+a corpus count. A reviewer that had been handed that warning still returned a wrong "cited by no
+`SKILL`" conclusion on this same branch.
+
+**The repair.** Names, not locations. The constants keep their names — the surrounding prose
+already named the functions, so names were the status quo and the line numbers plus the imperative
+were what was new — and the third budget cites `docs/ORCHESTRATION.md` §leaf transient retry, the
+canonical document, which this file already cited in that form at two other bullets. Citing the
+canonical DOCUMENT rather than the implementation is the general form: it survives a refactor, it
+is what `AGENTS.md` §"Dedicated rule documents" already prescribes, and it is not an instruction
+to open a tree the reader has been told not to read.
+
+**The generalization worth carrying.** Deleting a summary because it keeps coming out wrong is the
+right move (`atmofab-review-loop`'s "a summary of a spread is a claim with no witness"). What that
+move costs is that the mechanism has to be stated instead, and stating a mechanism invites
+pointers. On a guarded surface, decide where each pointer LANDS before you write it.

--- a/.claude/skills/atmofab-review-loop/SKILL.md
+++ b/.claude/skills/atmofab-review-loop/SKILL.md
@@ -464,7 +464,11 @@ nor resets the two-consecutive-clean-security-rounds condition.**
 - **Hand over this environment's trap**: in an agent session `grep` may be shadowed — a shell
   function execing `ugrep --ignore-files`, so it **respects `.gitignore`** (check with `type
   grep`). Have corpus measurements enumerate with `find` / `os.walk` (1 of 365 files was visible
-  once, and I nearly designed on "`interface` occurs 0 times")
+  once, and I nearly designed on "`interface` occurs 0 times"). **Handing it over is not enough,
+  and this one has now been measured from both ends**: on issue #168 a reviewer that had this
+  warning in its own prompt still returned "cited by no `SKILL`" for a document two `SKILL`s cite.
+  The reader-side rule is under "Verify a reviewer's negative claims" below — the writer-side
+  instruction does not close it
 - Write "report only what you ran. Give reproduction steps and file:line. **State explicitly if
   you found nothing**" — this prevents filler
 - **What you may hand over to reduce duplication is the axis, not the list.** "Hunk mutation over
@@ -639,6 +643,18 @@ trigger, not a second statement of the rule.)
 ratchet kills this hunk"; a test in another file caught it correctly and was simply outside the
 sweep's gate. **When told "only X caught it", check whether the files holding the other guards
 were inside that reviewer's test command.** If not, it is a report about the measurement scope.
+
+**An ABSENCE is a negative claim, and it is the one that arrives looking like a fact.** "X occurs
+nowhere", "no `SKILL` cites it", "no caller exists" reads as a measurement rather than as a
+conclusion, so it goes unchecked — and on this machine the default enumerator is wrong for it
+(`grep` shadowed by `ugrep --ignore-files`, which honours `.gitignore`). **Criterion: an absence
+claim is worth nothing until the reviewer names the ENUMERATOR.** `find` / `os.walk` counts; a
+bare `grep` does not, and neither does reading. Issue #168: one round-2 reviewer reported
+`docs/WORKSPACE_LAYOUT.md` as cited by no `SKILL` — `skills/workflow-generate-generate/SKILL.md`
+cites it, and a round-1 reviewer had already said so, so the two reports contradicted each other
+and only re-running it settled which was right. **Two reviewers disagreeing is the cheap case;
+the expensive one is a single absence claim nobody contradicts.** Ask for the command, or take
+the count yourself — it is one loop.
 
 **And verify a reviewer's POSITIVE claims by asking what it EXECUTED.** A "verified true" is
 worth exactly the run behind it, and a reviewer that traces a code path instead of driving it
@@ -1105,6 +1121,18 @@ that tells you how it closed.
   it rather than correct it; and **nothing in this loop catches these except the rendered prompt**
   — the sweep mutates code, the census enumerates code, a blank-slate reviewer reads code, and the
   suite stays green with the sentence inverted (measured, all three rounds)
+- **You DELETED a summary that kept coming out wrong and stated the mechanism instead** → right
+  move, and it has a price: stating a mechanism invites POINTERS, and a pointer onto a guarded
+  surface walks past the guard, because every guard here reads for a token and a `file:line`
+  contains none. `atmofab-enforcement-change` surface 13 owns the rule and the repair; the sign is
+  here because the trigger is a review-loop move — the same rewrite this file's "rewritten the
+  same string three times" row tells you to make. **Criterion: for each pointer the rewrite adds,
+  name what its TARGET holds that this surface forbids.** Issue #168 added four `tools/*.py:<line>`
+  citations plus "read them" to a document both verify `SKILL`s name in a list that forbids reading
+  `tools/`, and the severity allowlist stayed green because no severity VALUE was added. **Nothing
+  in this loop compares the branch to anything but itself, so nothing sees it**: what found it, in
+  round 3, was a corpus count of the citation FORM on the guarded surfaces at both revisions —
+  0 before, 4 after
 - **You have rewritten the same string three times** → the problem is not the rule but the prose
   citing it. Switch to the grep sweep
   (`.claude/skills/atmofab-enforcement-change/references/verification.md`). **Rewriting one


### PR DESCRIPTION
Two traps that PR #210's review loop sprang, written up where each belongs. `docs/DEVELOPMENT.md`
§Record placement names these skills as the home of what a review loop taught.

## Surface 13 — a gate that refuses a SPELLING does not refuse a POINTER to where it lives

The one worth reading. Every guard in this repository that protects a leaf-read surface decides by
reading the text for a token: `_SEVERITY_ROUTING_ALLOWLIST` refuses a severity VALUE, the
restatement scans refuse a known sentence. A `file:line` citation contains none of those tokens and
passes — while telling the reader exactly where to find them.

PR #210 did it to itself. A `docs/RUNBOOK.md` cost claim came out wrong three times, so the summary
was deleted and the mechanism stated instead — with four `tools/*.py:<line>` citations and the
sentence "Read the four constants for the run you are looking at". That document is in the CLOSED
judgment-rule list of both verify `SKILL`s, whose last sentence is "The implementation under
`tools/` ... must not be read to extract requirements or judgment rules", and the cited module
holds `classify_verify_severity`: in `dev` a `major` fail-closes the run, a `minor` buys a warm
same-phase repair turn. A verify leaf that follows the instruction learns which grade is the cheap
route to reporting its `substep` done. The allowlist stayed green the whole time, correctly — no
severity value was added.

**Rule**: when you add a REFERENCE to a surface some check guards, ask what the TARGET holds that
the check forbids HERE; the check cannot ask it for you. Prefer naming the fact, or the canonical
document that owns it, over naming the file and the line.

**Why nothing else caught it**, and this is the part that generalizes: the sweep mutates what
exists, the census enumerates what exists, a blank-slate reviewer reads HEAD — all three compare
the branch against itself, and against itself the bullet is accurate prose citing real lines. What
found it, in round 3, was a corpus count of the citation FORM taken at both revisions.
`references/input-surfaces.md` carries the `os.walk` reproduction.

The intro's surface count is re-derived from the bullets rather than incremented (eight → nine;
`grep -c "^- \*\*Surface [0-9]"` == 9). That sentence has been wrong twice before by addition and
the file says so.

## An ABSENCE is a negative claim

`atmofab-review-loop` already told you to hand reviewers this environment's `grep` trap — a shell
function running `ugrep --ignore-files`, which honours `.gitignore`. Measured on the same branch:
**a reviewer with that warning in its own prompt still returned "cited by no `SKILL`"** for a
document `skills/workflow-generate-generate/SKILL.md` cites. Handing it over does not close it.

So "Verify a reviewer's negative claims" gains the absence case. "X occurs nowhere" / "no caller
exists" arrives looking like a measurement and is a conclusion; it is worth nothing until the
reviewer names the ENUMERATOR. Two reviewers contradicting each other, which is what happened here,
is the cheap case — the expensive one is a single absence claim nobody contradicts.

A one-line sign in the same file points at Surface 13 rather than restating it. It lives there
because its trigger is a review-loop move: the "rewritten the same string three times → delete the
summary" row is what produces the rewrite that invites the pointers.

## One correction inside this PR's own subject

The episode first said the only other holder of the citation form was `docs/design/` — copied from
the reviewer's report rather than measured. Re-taken by `os.walk` at `4fbd40dd`: two documents hold
it, `docs/design/deterministic_followups.md` (5) and `TODO.md` (3), and no `SKILL` cites either.
Recorded as wrong rather than silently fixed. The rule against writing someone else's measurement
as your own applies to writing up the episode about it, which is how it caught me one paragraph
after I wrote the rule down.

## Verification

Suite 6024 passed / 3266 subtests. Both skills' own tests, which `pytest tools/tests` does not
collect: `atmofab-enforcement-change/scripts/tests` 18 passed, `atmofab-review-loop/scripts/tests`
52 passed. Every path cited in the new text resolves under `git ls-files`. Documentation only — no
code, no contract, no gate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159c9BroK4CGsr4J5hAMLuo
