### PR TITLE
#177 completion criterion 1: the emptiness grep was not empty

### DIFF
--- a/tools/tests/test_audit_orchestration.py
+++ b/tools/tests/test_audit_orchestration.py
@@ -1319,7 +1319,7 @@ class PureLeafABSummaryTest(unittest.TestCase):
     def _reserve(self, repo: Path, *, pipeline_id: str | None = None) -> None:
         """Write the pipeline reservation `prepare_node` writes before Compile runs.
 
-        This — NOT `orchestration_checkpoint.json` — is what discovery reads. The
+        This is what discovery reads. The
         checkpoint only ever carries a non-empty `pipeline_ref` for the `validate`
         step (verified against every real orchestration in-repo), so a fixture that
         hand-builds a compile/generate entry WITH a `pipeline_ref` encodes a shape
@@ -1620,7 +1620,7 @@ class PureLeafABSummaryTest(unittest.TestCase):
     def test_discovers_failed_and_rotated_source_dirs_with_no_checkpoint_at_all(self) -> None:
         # A terminally-failed generate is never checkpointed, and a cold restart
         # rotates to a fresh source dir. Discovery must find BOTH from the pipeline
-        # reservation alone — this fixture writes NO orchestration_checkpoint.json,
+        # reservation alone,
         # which is also the real shape of a generate-only run.
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
@@ -1717,9 +1717,7 @@ class PureLeafABSummaryTest(unittest.TestCase):
         # NOTHING. This fixture writes no checkpoint at all, which is that run's shape.
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
-            self._lay_out(repo)  # reservation + metas, no orchestration_checkpoint.json
-            ck = repo / "workspace" / "orchestrations" / self.ORCH / "orchestration_checkpoint.json"
-            self.assertFalse(ck.exists(), "fixture must have no checkpoint")
+            self._lay_out(repo)  # reservation + metas
             out = collect_pure_leaf_ab_summary(
                 repo, self.ORCH, {"invocation": {"generate_executor": "pure"}}
             )

--- a/tools/tests/test_orchestration_runtime.py
+++ b/tools/tests/test_orchestration_runtime.py
@@ -12121,9 +12121,6 @@ class PhaseCertificationTests(unittest.TestCase):
             repo = Path(tmp)
             self._preflight(repo)
             refs = self._certified(repo, through="compile")
-            self.assertFalse(
-                (repo / "workspace/orchestrations/o1/orchestration_checkpoint.json").exists())
-
             out = ort.check_phase_certified(
                 repo_root=repo, orchestration_id="o1", node_key=self._NK, step="compile",
                 agent_run_id="orch_run_001")

--- a/tools/tests/test_run_workflow.py
+++ b/tools/tests/test_run_workflow.py
@@ -711,7 +711,7 @@ class RunWorkflowTests(unittest.TestCase):
                 wc.run_conductor = orig_rc  # type: ignore[assignment]
             self.assertTrue(captured.get("wait_usage_reset"))
 
-    def test_resume_recovers_params_and_uses_checkpoint_init(self) -> None:
+    def test_resume_recovers_params_and_uses_the_resume_init(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
             self._seed_spec_tree(repo_root)

--- a/tools/tests/test_workflow_conductor.py
+++ b/tools/tests/test_workflow_conductor.py
@@ -1942,9 +1942,9 @@ class ConductRoutingTest(unittest.TestCase):
 
     def test_escalate_same_phase_build_validate_does_not_reopen(self) -> None:
         # The same-phase producer reopen is scoped to compile/generate (the only phases with a
-        # re-runnable LLM producer + reopen_phase carve-out). A diagnostician same-phase decision
-        # for validate (even with an explicit restart) must NOT fire the producer-reopen branch
-        # (which would crash reopen_phase) — it terminalizes.
+        # re-runnable LLM producer carve-out). A diagnostician same-phase decision
+        # for validate (even with an explicit restart) must NOT fire the producer-reopen
+        # branch — validate has no re-runnable producer, so it terminalizes instead.
         c = self._conductor()
         c.status_fn = lambda phase, substep, n: "fail" if (phase == "validate" and substep == "judge") else "pass"
         c.decision_fn = lambda phase, outcomes: wc.RouteDecision("escalate", reason="unclassified")
@@ -2948,9 +2948,10 @@ class TransportFailureTest(unittest.TestCase):
     def test_post_gate_unknown_escalates_in_prod(self) -> None:
         # G5: a post_judge `unknown` disposition routes to the unified escalate LLM in PROD —
         # run_phase returns a RouteDecision("escalate", reason="validate_post_judge_unknown"),
-        # writes no step_result, and does NOT fail_closed itself. It must NOT pre-tombstone the
-        # failed post_judge arid: conduct's diagnostician reopen uses it as the trigger, and
-        # reopen_phase no-ops on an already-superseded trigger, so the trigger stays live.
+        # writes no step_result, and does NOT fail_closed itself. The failed post_judge arid
+        # stays live as `conduct`'s rollback trigger. (Before issue #177 that was fragile: the
+        # trigger could be consumed by a tombstone and the reopen would then no-op. Nothing
+        # consumes a trigger now — `revoke-artifact` names the phase to re-derive, not a run.)
         import tempfile
         with tempfile.TemporaryDirectory() as td:
             repo = Path(td)
@@ -2999,9 +3000,10 @@ class TransportFailureTest(unittest.TestCase):
                 self.assertIn(status, ("fail", "fail_closed"))
 
     def test_post_gate_unknown_escalate_reopens_upstream(self) -> None:
-        # G5: when the diagnostician routes an upstream REOPEN (with budget remaining), conduct
-        # must NOT terminal-tombstone — doing so would pre-supersede the reopen trigger and make
-        # reopen_phase no-op. The reopen fires; reopen_phase supersedes the attempt instead.
+        # G5: when the diagnostician routes an upstream REOPEN (with budget remaining), the
+        # rollback fires and revokes the target's artifact. (Before issue #177 this test also
+        # had to pin that nothing pre-tombstoned the trigger, because that would have made the
+        # reopen a no-op; there are no tombstones now.)
         import tempfile
         with tempfile.TemporaryDirectory() as td:
             repo, refs = Path(td), self._refs()
@@ -5299,14 +5301,12 @@ class LeafTransientRetryTest(unittest.TestCase):
                     for s, cap in c.calls if s == "record-launch"]
         self.assertEqual(launched, ["child-1", "child-2"])
         self.assertEqual(oc.agent_run_id, "child-2")
-        # the dead attempt is tombstoned: terminalized but never vouched, it would otherwise be
-        # an orphan edge that fails _validate_orchestration_completion_for_pass at the end of an
-        # otherwise-passing run
-        # Ordering: record-launch -> finalize-child -> add-superseded-runs -> next record-launch.
-        # finalize-child MUST come first (see test_tombstone_writes_are_outside_the_leafs_write_
-        # window below: the tombstone's own files land in the child's FS diff otherwise, and the
-        # dying leaf is rejected for the conductor's writes), and it must precede the next launch
-        # (the runtime fail-closes a launch while a child of this parent is still active).
+        # The dead attempt needs no tombstone since issue #177: a terminal arid no step_result
+        # vouches is simply a failed attempt, where it used to be an orphan edge that failed
+        # `_validate_orchestration_completion_for_pass` at the end of an otherwise-passing run.
+        # Ordering: record-launch -> finalize-child -> next record-launch. finalize-child must
+        # precede the next launch (the runtime fail-closes a launch while a child of this parent
+        # is still active).
         subs = [s for s, _ in c.calls]
 
     def test_recovered_retry_vouches_only_the_survivor_in_the_step_result(self) -> None:
@@ -6260,26 +6260,6 @@ class LeafTransientRetryTest(unittest.TestCase):
         # every attempt gets its own request.json (its own arid), so nothing is overwritten
         reqs = [cap["--request-json"] for s, cap in c.calls if s == "record-launch"]
         self.assertEqual([r["agent_run_id"] for r in reqs], ["child-1", "child-2"])
-
-    def test_tombstone_writes_are_outside_the_leafs_write_window(self) -> None:
-        from tools.orchestration_runtime import _should_ignore_runtime_snapshot_path as ignored
-        for path in ("workspace/orchestrations/orch_x/reopen/superseded_runs.json",
-                     "workspace/orchestrations/orch_x/reopen/reopen_log.jsonl"):
-            self.assertFalse(
-                ignored(path, orchestration_id="orch_x", agent_run_id="child-1"),
-                f"{path} is visible in a child's FS diff — the tombstone must not run inside "
-                f"a child's write window")
-        # ...and the loop honours that: no tombstone is issued between a record-launch and its
-        # matching finalize-child.
-        c = self._conductor([self._flake(), wc.ProcResult(0, "done", "")])
-        with redirect_stdout(io.StringIO()):
-            c.run_substep(self._refs(), "compile", "verify")
-        open_window = False
-        for sub, _cap in c.calls:
-            if sub == "record-launch":
-                open_window = True
-            elif sub == "finalize-child":
-                open_window = False
 
     def test_retried_judge_cannot_certify_the_dead_attempts_semantic_review(self) -> None:
         """The retry must not let a leaf that NEVER COMPLETED certify the node.


### PR DESCRIPTION
Issue #177, completion sweep. Plan §3 criterion 1 requires

```
grep -rn 'reopen_phase\|add-superseded-runs\|superseded_runs\|orchestration_checkpoint\|resume_enabled\|_probe_driver_liveness' \
  tools docs skills --exclude=deterministic_followups.md
```

to come back **empty**. At the merge of all three PRs it returned **19 hits**. This closes them.

## What the 19 were

**1 dead test.** `test_tombstone_writes_are_outside_the_leafs_write_window` pinned a property of a mechanism that no longer exists — that `reopen/superseded_runs.json` and `reopen/reopen_log.jsonl` are visible in a child's FS diff, so the tombstone must not run inside a child's write window. Nothing writes either file. Deleted.

**7 comments and fixtures describing deleted machinery in the present tense**, each of which explains why live code has the shape it does — the dangerous kind, because the next reader takes the explanation as the reason:

- "`reopen_phase` no-ops on an already-superseded trigger, so the trigger stays live"
- "doing so would pre-supersede the reopen trigger and make `reopen_phase` no-op"
- an ordering justified by an `add-superseded-runs` call between two steps that no longer bracket anything
- "(which would crash `reopen_phase`)" as the reason for a branch whose real reason is that validate has no re-runnable producer

Rewritten to say what holds now, keeping the history where it explains a decision. Two fixtures asserted the ABSENCE of `orchestration_checkpoint.json`, which is vacuous once nothing can write it.

**8 deliberate past-tense records, kept.** Rewriting these in today's vocabulary would delete the record rather than update it — the same reasoning plan decision 17 uses to exclude `docs/design/deterministic_followups.md`:

| site | what it records |
|---|---|
| `docs/GLOSSARY.md:61` | `revoke-artifact`'s definition naming what it replaced |
| `docs/ORCHESTRATION.md:301` | rule 44 recording what #177 deleted and why a ledger cannot decide a skip |
| `tools/orchestration_runtime.py:1758` | why artifact hashes replace the ledger |
| `tools/orchestration_runtime.py:6047` | that the plan listed `merge_phase_state_for_resume` for deletion BY NAME, and why reading the body overruled it |
| `tools/orchestration_runtime.py:14967` | `enable_checkpoint_resume` → `resume_orchestration`, and why the old name described neither input nor effect |
| `tools/workflow_conductor.py:13660` | why this return had to tombstone nothing first, back when a tombstone could disarm the rollback |
| 2 test docstrings | what a mutation measured |

## Criterion 3, re-measured at this commit

`grep -rn "def test_.*\(checkpoint\|resume\|reopen\|supersed\)" tools/tests/*.py | wc -l` = **158**

| point | count |
|---|---|
| before issue #177 | 226 |
| after PR-1 + PR-2 | 170 |
| after PR-3 | 158 |

The residue was read rather than assumed. Six `supersed` names are a **different concept** — a nonpass run resolved by a later passing run of the same key, reconciled by replay order; `tools/run_workflow.py` says in place that the `superseded` / `superseded_by` fields are not written. The `resume` names are warm-repair, issue #209, and this issue's own new tests. One stale name, `test_resume_recovers_params_and_uses_checkpoint_init`, is renamed.

## Verification

Suite **5997 passed / 0 failed**. ruff **1523**.

## Still open

**Criterion 2 — the billed end-to-end run** has not been done. It is the last item of plan §3 and needs the operator's go-ahead, since it spends LLM budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159c9BroK4CGsr4J5hAMLuo